### PR TITLE
docs(prompts): add routing/cache-idem/qa-perf-release prompts v1

### DIFF
--- a/docs/policy-prompts/10_api-specs/01_openapi_lite_prompt.md
+++ b/docs/policy-prompts/10_api-specs/01_openapi_lite_prompt.md
@@ -1,0 +1,97 @@
+# 📘 실행 프롬프트 — API 명세서(OpenAPI-lite) 전용 v1.0
+
+**ROLE**
+너는 KO-first 백엔드 아키텍트다. **설명 금지**, **결정적 사양만** 출력한다.
+
+**GOAL**
+아래 9개 엔드포인트의 **OpenAPI-lite 명세**를 한 문서로 산출한다. 각 엔드포인트마다: 요청/응답 JSON 스키마(draft-2020-12), 헤더·보안, 상태코드, 정상/에러 예시를 포함한다.
+
+**ENDPOINTS (고정)**
+- `POST /api/v1/report/saju`
+- `POST /api/v1/chat/send`
+- `POST /api/v1/luck/annual`
+- `POST /api/v1/luck/monthly`
+- `POST /api/v1/tokens/reward`   *(리워디드 광고 SSV)*
+- `POST /api/v1/tokens/consume`
+- `GET  /api/v1/entitlements`
+- `POST /api/v1/report/pdf`
+- `POST /api/v1/profiles`
+
+**CONTEXT (고정 사실)**
+- 서비스 체인: tz-time → astro → pillars → analysis → luck(연/월) → llm-polish → LLMGuard → Gateway
+- 정책/데이터 파일: `strength_policy_v2.json`, `relation_policy.json`, `shensha_v2_policy.json`, `gyeokguk_policy.json`, `yongshin_policy.json`, `branch_tengods_policy.json`, `sixty_jiazi.json`, `localization_ko_v1.json`
+- 신규 모듈(명세 참조만): `TwelveStageCalculator`, `VoidCalculator`, `YuanjinDetector`, `CombinationElementTransformer`, `AnnualLuckCalculator`, `MonthlyLuckCalculator`
+
+---
+
+## OUTPUT FORMAT (반드시 준수)
+
+### 1) 문서 헤더
+- 제목, 버전, 날짜(KST), 베이스 URL(placeholder), 인증 방식(Bearer)
+
+### 2) 글로벌 규칙
+- **보안**: `Authorization: Bearer <token>`
+- **요청 헤더**: `X-Request-Id`(필수), `Idempotency-Key`(멱등 필요한 POST에 권장)
+- **응답 헤더**: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
+- **에러 모델(공통)**:
+  ```json
+  { "error_code": "E_BAD_REQUEST", "message": "KO 설명", "trace_id": "…", "hint": "…" }
+  ```
+- **JSON 서명 규칙**: 모든 응답 예시에 `signatures.sha256`(RFC-8785 canonical JSON 기준) 필드 포함
+
+### 3) 엔드포인트별 스펙(각각 제공)
+- 요약/설명(짧게)
+- 요청 스키마: JSON Schema draft-2020-12 (타입/enum/format/min/max/required)
+- 응답 스키마: 성공/에러(공통 에러 스키마 참조)
+- 상태코드: 200/201/400/401/403/404/409/422/429/500 중 해당 값
+- 헤더: 요청/응답에 요구되는 헤더 명시
+- 예시: 정상 1개, 에러 1개(에러는 한국어 message와 표준 error_code)
+- 비고: 캐시/TTL, 멱등, 레이트리밋, 페이징(해당 시)
+
+### 4) 공통 컴포넌트(스키마 섹션)
+- Profile
+- ReportSajuResponseSummary
+- ChatResponseSummary
+- LuckAnnual
+- LuckMonthly
+- Entitlements
+- TokensRewardRequest/Response
+- TokensConsumeRequest/Response
+- PdfJob
+- 에러코드 테이블: `E_BAD_REQUEST`, `E_UNAUTHORIZED`, `E_FORBIDDEN`, `E_NOT_FOUND`, `E_CONFLICT`, `E_RATE_LIMIT`, `E_UNPROCESSABLE`, `E_SERVER`
+
+### 5) 부록
+- 필드 제약 요약:
+  - `birth_dt_local` ISO 8601 date-time
+  - `calendar_type` ∈ {solar, lunar}
+  - `zi_hour_mode` ∈ {split_23, default}
+  - IANA TZ 패턴: `^[A-Za-z]+/[A-Za-z_]+(?:/[A-Za-z_]+)?$`
+- 샘플 값 메모: 최소 1개 예시에 `unknown_hour:true`, `zi_hour_mode:"split_23"`, `regional_correction_minutes:-32` 포함
+
+---
+
+## SCHEMA HINTS (지켜라)
+
+- `/api/v1/report/saju` 응답 최상위 키: `meta`, `time`, `pillars`, `analysis`, `localization`, `evidence`, (옵션) `entitlements`, (옵션) `ads_suggest`
+- `/api/v1/chat/send` 응답: `cards[]`, `llm_text`, `consumed{tokens,depth}`, `upsell{show,reason,options[]}`, `next_cta[]`
+- `/api/v1/tokens/reward`: `idempotency_key`, `network`, `receipt`, `cooldown_sec`, `daily_cap`
+- `/api/v1/entitlements`: `plan`, `storage_limit`, `stored`, `light_daily_left`, `deep_tokens` 등
+- `/api/v1/luck/*` 응답 메타에 `cache_ttl_sec` 표기 권장(연 365d, 월 30d)
+
+---
+
+## STYLE
+
+- KO-first, 간결/정확/중립
+- 임의 가정 최소화. 필요한 기본값/enum은 합리적으로 지정
+- 표/코드블록(JSON Schema) 혼합 표현
+
+---
+
+## ACCEPTANCE CRITERIA
+
+- 9개 엔드포인트 모두 요청/응답 스키마 + 정상/에러 예시 + 상태코드/헤더 포함
+- 공통 에러 모델/코드표/보안/헤더/서명 규칙이 문서 상단과 컴포넌트에 정의
+- `/report/saju`와 `/chat/send`는 샘플 JSON이 120~200줄 내로 포함
+- 최소 1개 예시에 `unknown_hour:true`, `zi_hour_mode:"split_23"`, `regional_correction_minutes:-32` 등장
+- 문서 전체를 한 번에 복사-저장 가능한 단일 명세로 출력

--- a/docs/policy-prompts/10_api-specs/02_report_schema_prompt.md
+++ b/docs/policy-prompts/10_api-specs/02_report_schema_prompt.md
@@ -1,0 +1,85 @@
+# 📘 실행 프롬프트 — `/report/saju` JSON Schema + 샘플 전용 v1.0
+
+**버전**: v1.0
+**날짜**: 2025-10-07 KST
+**경로 권장**: `docs/policy-prompts/10_api-specs/02_report_schema_prompt.md`
+
+---
+
+## ROLE
+너는 KO-first 스키마 엔지니어다. 설명 대신 **결정적 산출물**만 출력한다.
+
+## GOAL
+`POST /api/v1/report/saju`의 **정식 JSON Schema (draft-2020-12)**와 **샘플 응답 2건**을 산출한다. 스키마는 **유효성 검증 가능**해야 하며, 필드 설명(`description`)과 제약을 포함한다.
+
+## CONTEXT (고정 사실)
+- 상위 키: `meta`, `time`, `pillars`, `analysis`, `localization`, `evidence`, *(옵션)* `entitlements`, *(옵션)* `ads_suggest`.
+- 기존 정책/데이터: `strength_policy_v2.json`, `relation_policy.json`, `shensha_v2_policy.json`, `gyeokguk_policy.json`, `yongshin_policy.json`, `branch_tengods_policy.json`, `sixty_jiazi.json`, `localization_ko_v1.json`.
+- KO-first 라벨 필요: 가능한 곳에 `*_ko` 보조 필드 포함.
+- RFC-8785 canonical JSON + `signatures.sha256` 예시 필드 포함.
+
+## MUST INCLUDE (필수 스키마 세부)
+1) **`meta`**
+   - `name`(string), `gender`(enum: `male`/`female`/`other`), `school_profile`(string), `signatures.sha256`(string, pattern SHA-256 hex).
+2) **`time`**
+   - `timezone`(IANA, pattern), `dst`(boolean), `utc`(ISO8601 `date-time`),
+   - `lmt`(string `date-time`), `regional_correction_minutes`(integer, -180..+180),
+   - `solar_time`(string `date-time`), `evidence`(object).
+3) **`pillars`**
+   - `year|month|day|hour` → `{ stem, branch, sexagenary }` (모두 string; 10간/12지/60갑자 유효성 enum 또는 패턴),
+   - `meta.zi_hour_mode`(enum: `default`/`split_23`).
+4) **`analysis`**
+   - `ten_gods.by_pillar.{year,month,day,hour}.{heavenly,earth}`(string enum 10개),
+   - `ten_gods.stats.percent`(object of number 0..100),
+   - `relations.{heavenly,earth}.{combine,clash,xing,po,hai,he6,sanhe,directional,yuanjin}`(array of arrays with items string),
+   - `void.kong_wang`(array of branch strings),
+   - `life_stage.by_pillar.*`(enum: 장생~양 12단계),
+   - `shensha.summary[]`(string), `shensha.by_pillar.*[]`(string),
+   - `strength.{score(0..100), bucket(enum), factors[]}`,
+   - `structure.{primary,status,score}`,
+   - `climate.{needs[],notes[]}`,
+   - `yongshin.{type,elements[],rationale}`(객관 필드 중심),
+   - `wuxing.{raw.percent{木,火,土,金,水}, adjusted? , status_tag{…}}`(각 0..100 합<=100),
+   - `luck.{decades{start_age(0..20),direction(enum:forward|reverse),pillars[]}, years{ YYYY }, months{ YYYY-MM }}`.
+5) **`localization`**
+   - `ko`(boolean).
+6) **`evidence`**
+   - `policies_applied[]`(string), `trace_id`(string), `inputs_hash`(string).
+7) **`entitlements` (optional)**
+   - `plan`(enum: `free`/`plus`/`pro`), `storage_limit`(int), `stored`(int),
+   - `light_daily_left`(int), `deep_tokens`(int).
+8) **`ads_suggest` (optional)**
+   - `eligible`(boolean), `cooldown_min`(int ≥0).
+
+## VALIDATION RULES
+- ISO8601 `date-time` 포맷 적용.
+- IANA TZ: `^[A-Za-z]+/[A-Za-z_]+(?:/[A-Za-z_]+)?$` 패턴.
+- 10간/12지/60갑자/십신/12운성/신살 등은 **enum**으로 강제(대표 subset 포함, 필요시 `"enumComment"`로 전체 목록 참고 링크 설명).
+- 수치 필드는 범위 강제(예: percent 0..100, score 0..100).
+- `months` 키는 `^(19|20|21)\\d{2}-(0[1-9]|1[0-2])$` 패턴, `years` 키는 `^(19|20|21)\\d{2}$`.
+
+## SAMPLES (2건 모두 제공)
+- **샘플 A(표준)**: 정상 시간, `zi_hour_mode:"default"`, `regional_correction_minutes:0`.
+- **샘플 B(엣지)**: `unknown_hour:true` 시나리오를 반영해 `pillars.hour`를 `null` 처리, `meta.zi_hour_mode:"split_23"`, `regional_correction_minutes:-32`, `ads_suggest.eligible:true`.
+- 두 샘플 모두 `signatures.sha256` 값(32바이트 hex) 포함, `wuxing.raw.percent` 합이 100이 되도록 숫자 설정.
+
+## OUTPUT FORMAT (반드시 이 순서)
+1) 제목/버전/날짜(예: 2025-10-07 KST), 간단 개요
+2) **JSON Schema (draft-2020-12)** — 단일 최상위 스키마, `$defs`에 재사용 구조(`Pillar`, `TenGod`, `WuxingPercent` 등) 분리
+3) **샘플 응답 A (정상)** — 120~180줄 내
+4) **샘플 응답 B (엣지/시간 모름)** — 120~180줄 내
+5) **검증 힌트** — `ajv`/`jsonschema`로 검증 시 주의점(예: patternProperties로 `years`/`months` 키 검증)
+
+## STYLE
+- KO-first, 간결·정확·중립.
+- 임의 서사 금지. 스키마와 예시만.
+- 주석 대신 `description` 필드를 사용.
+
+## ACCEPTANCE CRITERIA
+- 스키마는 draft-2020-12 `$schema` 선언 포함.
+- 필수/옵션/enum/범위/패턴이 명확.
+- 샘플 A/B 모두 스키마에 **유효**해야 하며, B에 `unknown_hour:true`, `split_23`, `-32`가 등장.
+- `entitlements`/`ads_suggest`가 **옵션**으로 스키마에 정의되고, 샘플 중 최소 1건에서 등장.
+
+## NOW OUTPUT
+위 조건을 충족하는 **단일 문서**를 생성하라.

--- a/docs/policy-prompts/10_api-specs/03_chat_send_spec_prompt.md
+++ b/docs/policy-prompts/10_api-specs/03_chat_send_spec_prompt.md
@@ -1,0 +1,209 @@
+# 📘 실행 프롬프트 — `/chat/send` 오케스트레이터 스펙 v1.0
+
+**버전**: v1.0
+**날짜**: 2025-10-07 KST
+**경로 권장**: `docs/policy-prompts/10_api-specs/03_chat_send_spec_prompt.md`
+
+---
+
+## ROLE
+너는 KO-first 백엔드/플랫폼 아키텍트다. 설명 대신 **결정적 사양**만 출력한다.
+
+## GOAL
+`POST /api/v1/chat/send`의 **완전한 사양**을 산출한다:
+- 상태머신(Quota→Intent→Context→Pre-Guard→Template→LLM→Post-Guard→Consume→Respond)
+- 모델 라우팅 정책(Light/Deep/Fallback)
+- 요청/응답 **JSON Schema(draft-2020-12)**
+- 정상/에러 예시
+- 헤더/보안/레이트리밋/멱등·재시도 규칙
+
+## CONTEXT(고정)
+- 채팅은 **저장된 프로필**(pillars/analysis/luck 캐시)을 컨텍스트로 사용.
+- **Light**(≤300t): 짧은 코칭 요약, **토큰 소모 0**.
+- **Deep**(≤900t): 상세 코칭+날짜 추천, **토큰 1 소비**.
+- Free/Plus/Pro 권한·토큰 정책은 별도 API(`/entitlements`, `/tokens/*`)가 담당.
+- 결과 카드는 **룰 기반(엔진 산출)**, 텍스트는 **템플릿→LLM-polish**.
+- Guard: **Consistency(수치·간지·날짜 일치), Scope(민감 주제), Tone, Privacy, Grounding**.
+
+## OUTPUT ORDER (반드시 이 순서)
+1) 문서 헤더(제목/버전/날짜/베이스URL/보안)
+2) **상태머신 정의**(텍스트 + 표 + 의사코드)
+3) **모델 라우팅 정책** 표(라이트/딥/백스탑·타임아웃·재시도)
+4) **요청/응답 JSON Schema(draft-2020-12)**
+5) **정상 예시 2건**(Light/Deep) + **에러 예시 2건**(Quota/Guard)
+6) **헤더/레이트리밋/멱등·재시도/타임아웃 규칙**
+7) **검증 체크리스트**(필드 유효성·가드 키 일치·토큰 소비 이벤트)
+
+## 상태머신(필수 요구사항)
+- **S0 Quota Check**: `/entitlements` 조회 → 저장 한도, `light_daily_left`, `deep_tokens`. 부족 시 **Upsell 응답**(광고/토큰팩/플랜).
+- **S1 Intent Classifier**: `intent ∈ {today, month, year, money, work, study, move, love, match, general}` + `depth ∈ {auto, light, deep}` 결정.
+- **S2 Context Build**: `profiles/{id}` → `pillars`, `analysis`, `luck.years[YYYY]`, `luck.months[YYYY-MM]` 캐시 로드.
+- **S3 Pre-Guard**: 금지 토픽(의료/법률/투자 구체행위), 개인정보 과노출 차단.
+- **S4 Template Compose**: 카드(룰 기반) + 문장 슬롯 초안(draft).
+- **S5 LLM Polish**: 모델 호출(Light/Deep 상한 적용).
+- **S6 Post-Guard**: 컨텍스트 값과 **정합성 검사**, 위반 시 자동 패치 또는 "정보 없음".
+- **S7 Consume**: `tokens/consume`(deep이면 1, light이면 0) 멱등 처리.
+- **S8 Respond**: `cards[]`, `llm_text`, `consumed`, `upsell`, `next_cta[]`.
+
+> 실패 분기: S0/S3/S6 단계에서 실패 시 **안전 응답**(가이드 문구 + 카드만)로 종료.
+
+## 모델 라우팅 정책(표)
+| Depth | 1차 | 2차(Fallback) | 3차(Backstop) | 타임아웃 | 재시도 | 메모 |
+|---|---|---|---|---|---|---|
+| Light | Qwen Flash **or** DeepSeek-Chat | Gemini 2.5 Pro | GPT-5 | 3s/7s/10s | 네트워크 1회 | 비용 최소·한글 품질 확보 |
+| Deep | Gemini 2.5 Pro | GPT-5 | — | 8s/15s | 네트워크 1회 | 롱컨텍스트/안정 서술 |
+| Report-style 텍스트 | Gemini 2.5 Pro | GPT-5 | — | 12s | 0 | 채팅 내 소규모 리포트 |
+
+> Guard 위반/정합성 실패 시 **즉시 상위 모델 재시도 금지**, 먼저 **템플릿 축약** 후 동일 모델 1회 재시도.
+
+## 요청/응답 JSON Schema (draft-2020-12)
+
+### Request Schema
+- 필수: `profile_id`, `message`
+- 선택: `depth`, `intent`, `locale`(기본 `ko-KR`), `client_ts`
+- 제약: `profile_id` UUID, `message` 길이 1–2000, `depth ∈ {auto,light,deep}`
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/chat_send_request.schema.json",
+  "type": "object",
+  "required": ["profile_id", "message"],
+  "properties": {
+    "profile_id": { "type": "string", "format": "uuid", "description": "저장 프로필 ID" },
+    "message": { "type": "string", "minLength": 1, "maxLength": 2000, "description": "사용자 입력" },
+    "depth": { "type": "string", "enum": ["auto", "light", "deep"], "default": "auto" },
+    "intent": { "type": "string", "enum": ["today","month","year","money","work","study","move","love","match","general"], "nullable": true },
+    "locale": { "type": "string", "default": "ko-KR" },
+    "client_ts": { "type": "string", "format": "date-time", "nullable": true }
+  },
+  "additionalProperties": false
+}
+```
+
+### Response Schema
+핵심: `cards[]`(룰 결과 카드), `llm_text`(해설), `consumed{tokens,depth}`, `upsell{show,reason,options[]}`, `next_cta[]`
+카드 타입 예: `wuxing_summary`, `relations_highlight`, `strength_bucket`, `luck_snippet`(7일/1기 티저)
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/chat_send_response.schema.json",
+  "type": "object",
+  "required": ["cards", "llm_text", "consumed"],
+  "properties": {
+    "cards": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type","data"],
+        "properties": {
+          "type": { "type": "string", "enum": ["wuxing_summary","relations_highlight","strength_bucket","luck_snippet","notice"] },
+          "data": { "type": "object" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "llm_text": { "type": "string", "description": "LLM-polish 결과 텍스트" },
+    "consumed": {
+      "type": "object",
+      "required": ["tokens","depth"],
+      "properties": {
+        "tokens": { "type": "integer", "minimum": 0 },
+        "depth": { "type": "string", "enum": ["light","deep"] }
+      }
+    },
+    "upsell": {
+      "type": "object",
+      "required": ["show"],
+      "properties": {
+        "show": { "type": "boolean" },
+        "reason": { "type": "string", "nullable": true, "enum": ["no_deep_tokens","rate_limited","forbidden_topic","plan_restricted",null] },
+        "options": { "type": "array", "items": { "type": "string", "enum": ["watch_ad","buy_tokens","subscribe_plus","subscribe_pro"] } }
+      }
+    },
+    "next_cta": { "type": "array", "items": { "type": "string" } },
+    "signatures": {
+      "type": "object",
+      "properties": {
+        "sha256": { "type": "string", "pattern": "^[A-Fa-f0-9]{64}$" }
+      }
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+## 정상/에러 예시
+
+### 정상 — Light
+```json
+{
+  "cards": [
+    { "type":"wuxing_summary","data":{"percent":{"木":25,"火":15,"土":15,"金":35,"水":10},"status_tag":{"金":"over","木":"developed"}} },
+    { "type":"relations_highlight","data":{"earth":{"clash":[["巳","亥"]],"he6":[["酉","辰"]]}} }
+  ],
+  "llm_text": "요약: 금 기운이 강해 규칙과 마감 준수가 이득입니다. 이번 주는 충이 있어 갈등을 피하고 문서 정리를 먼저 하세요.",
+  "consumed": { "tokens": 0, "depth": "light" },
+  "upsell": { "show": false },
+  "next_cta": ["이번 달 달력 보기","용신 설명 자세히"],
+  "signatures": { "sha256": "5bdc0b7b2a1d0f3a8e2a7e5cc0e6ff9f3f2c1d5e0b9a7d6c4f1a2b3c4d5e6f70" }
+}
+```
+
+### 정상 — Deep
+```json
+{
+  "cards": [
+    { "type":"strength_bucket","data":{"score":38,"bucket":"weak","factors":["월령 미득령","비겁 부족"]} },
+    { "type":"luck_snippet","data":{"month":"2025-10","pillar":"丙戌","ten_god":"정재","stage":"묘","range":"D+1~D+7"} }
+  ],
+  "llm_text": "상세: 이번 달은 정재가 활성화되어 지출 관리와 정리 정돈이 핵심입니다. 10/12~10/14에는 문서·비품 정리가 유리하고, 계약은 10/22 이후가 안정적입니다.",
+  "consumed": { "tokens": 1, "depth": "deep" },
+  "upsell": { "show": false },
+  "next_cta": ["PDF 리포트 받기","대운 타임라인 보기"],
+  "signatures": { "sha256": "e3c1abf0e5a2d9c48b1a0f2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8090a1b2c3" }
+}
+```
+
+### 에러 — Quota/토큰 부족(업셀)
+```json
+{
+  "cards": [
+    { "type":"notice","data":{"title":"딥 응답 이용 불가","detail":"오늘 남은 Deep 이용 가능 횟수가 없습니다."} }
+  ],
+  "llm_text": "광고를 시청하거나 토큰팩을 구매하면 상세 풀이를 받을 수 있어요.",
+  "consumed": { "tokens": 0, "depth": "light" },
+  "upsell": { "show": true, "reason": "no_deep_tokens", "options": ["watch_ad","buy_tokens","subscribe_plus"] }
+}
+```
+
+### 에러 — Guard 위반(민감 주제)
+```json
+{
+  "cards": [
+    { "type":"notice","data":{"title":"안전 가이드","detail":"해당 주제는 구체적 의료/투자 조언을 제공하지 않습니다. 대신 일상 관리 팁을 안내합니다."} }
+  ],
+  "llm_text": "안전: 건강/투자 관련 구체 행위는 제시하지 않고, 기록·예산·상담 등 일반적 습관을 권장합니다.",
+  "consumed": { "tokens": 0, "depth": "light" },
+  "upsell": { "show": false }
+}
+```
+
+## 헤더/레이트리밋/멱등·재시도/타임아웃
+
+**보안**: `Authorization: Bearer <token>`
+**요청 헤더**: `X-Request-Id`(필수), `Idempotency-Key`(선택; 동일 입력 재시도 시 중복 방지)
+**응답 헤더**: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
+**레이트리밋**: 기본 60 RPM/프로젝트(플랜별 상향)
+**타임아웃**: Light 3s(1차) / Deep 8s(1차); Fallback 포함 최대 15s
+**재시도**: 네트워크 오류 1회, Guard 위반 시 상위 모델 즉시 승격 금지(템플릿 축약 후 동일 모델 재시도)
+
+## 검증 체크리스트
+
+- [ ] `profile_id` 소유권 검증
+- [ ] `intent`/`depth` 유효값 확인; `depth=auto`일 때 룰 기반 결정
+- [ ] 컨텍스트(`pillars`/`analysis`/`luck`) 캐시 로드 실패 시 카드만 제공 + 안전 텍스트
+- [ ] Post-Guard: `llm_text` 내 간지·날짜·퍼센트가 컨텍스트와 일치하는지 검증
+- [ ] `consumed.tokens` 정확 기록 + `tokens/consume` 멱등 처리
+- [ ] Upsell 사유/옵션 표준화(`no_deep_tokens`, `rate_limited`, `plan_restricted`, `forbidden_topic`)

--- a/docs/policy-prompts/20_policy-engines/annual_monthly_luck_prompt.md
+++ b/docs/policy-prompts/20_policy-engines/annual_monthly_luck_prompt.md
@@ -1,0 +1,777 @@
+# 📘 실행 프롬프트 — 연운/월운 계산기 스펙 v1.0
+
+**버전**: v1.0
+**날짜**: 2025-10-07 KST
+**경로 권장**: `docs/policy-prompts/20_policy-engines/annual_monthly_luck_prompt.md`
+
+---
+
+## ROLE
+너는 KO-first 정책/엔진 아키텍트다. 설명 대신 **결정적 산출물**만 출력한다.
+
+## GOAL
+**2개 엔진**의 완전한 사양을 산출한다:
+1. **AnnualLuckCalculator** (연운: 년주 + 대운 조합, 십신/12운성/태세)
+2. **MonthlyLuckCalculator** (월운: 월주 + 길흉일 계산, 7일 티저)
+
+각 엔진별 **I/O JSON Schema, 결정 규칙, 의사코드, 캐시 전략, 엣지 케이스, 단위 테스트 명세**를 포함한다.
+
+## CONTEXT (고정 사실)
+- **연운 (Annual Luck)**: 현재 대운 + 해당 년주 → 십신/12운성/태세(太歲)/길흉 종합
+- **월운 (Monthly Luck)**: 해당 월주 + 일별 길흉 → good_days/caution_days (1~31일)
+- **대운 (Decades Luck)**: 이미 LuckCalculator에서 계산됨 (`luck.decades.pillars[]`, `start_age`, `direction`)
+- **캐시**: 연운 365일 TTL, 월운 30일 TTL (RFC-8785 서명 기반)
+- **API 엔드포인트**: `POST /api/v1/luck/annual`, `POST /api/v1/luck/monthly`
+- KO-first 라벨: `*_ko` 병행
+
+## OUTPUT ORDER (반드시 이 순서)
+1) 문서 헤더 (제목/버전/날짜)
+2) **AnnualLuckCalculator 사양** (I/O Schema, 결정 규칙, 의사코드, 캐시, 엣지 케이스, 테스트)
+3) **MonthlyLuckCalculator 사양** (I/O Schema, 결정 규칙, 의사코드, 캐시, 엣지 케이스, 테스트)
+4) **API 엔드포인트 스키마** (요청/응답 JSON Schema draft-2020-12)
+5) **캐시 전략** (키 구조, TTL, 무효화 규칙)
+6) **통합 체크리스트** (엔진 구현/API 통합/테스트)
+
+---
+
+## 1. AnnualLuckCalculator 사양
+
+### 1.1 I/O JSON Schema
+
+**Input:**
+```json
+{
+  "profile_id": "550e8400-e29b-41d4-a716-446655440000",
+  "year": 2025,
+  "birth_data": {
+    "day_stem": "乙",
+    "gender": "male",
+    "birth_dt": "2000-09-14T10:00:00+09:00"
+  },
+  "current_decade": {
+    "pillar": "甲申",
+    "start_age": 7.98,
+    "direction": "reverse"
+  }
+}
+```
+
+**Output:**
+```json
+{
+  "year": 2025,
+  "year_pillar": {
+    "stem": "乙",
+    "branch": "巳",
+    "sexagenary": "乙巳",
+    "stem_ko": "을",
+    "branch_ko": "사",
+    "sexagenary_ko": "을사"
+  },
+  "ten_god": "比肩",
+  "ten_god_ko": "비견",
+  "life_stage": "病",
+  "life_stage_ko": "병",
+  "tai_sui": {
+    "branch": "巳",
+    "element": "火",
+    "conflict_with_birth": ["巳亥沖"]
+  },
+  "annual_score": 68.5,
+  "tags": ["比肩年", "巳亥沖", "자시전환주의"],
+  "summary": {
+    "strength": "neutral",
+    "fortune": "caution",
+    "key_months": ["2025-03", "2025-09"]
+  }
+}
+```
+
+### 1.2 결정 규칙
+
+**연운 계산 흐름:**
+1. **년주 조회**: 해당 년도의 천간/지지 결정 (예: 2025년 = 乙巳)
+2. **십신 계산**: 일간 vs 년간 → 십신 (예: 乙일간 vs 乙년간 = 比肩)
+3. **12운성 계산**: 일간 + 년지 → 12운성 (TwelveStageCalculator 사용)
+4. **태세 (太歲)**: 년지의 원소 + 본명과의 충/형/해 관계
+5. **연운 점수**: 십신 강약 + 12운성 + 대운 조합 → 0~100 점수
+6. **태그 생성**: ["比肩年", "巳亥沖", "자시전환주의"] 등
+7. **주요 월 추천**: 연운 기반 유리한/주의할 월 (예: 3월, 9월)
+
+**연운 점수 공식:**
+```python
+score = (
+    ten_god_weight * 30 +      # 십신 가중치
+    life_stage_weight * 25 +   # 12운성 가중치
+    decade_harmony * 20 +      # 대운 조화도
+    tai_sui_impact * 15 +      # 태세 영향
+    relation_boost * 10        # 합충형파해 보정
+)
+```
+
+**십신 가중치 (예시):**
+- 比肩/劫財: 중립 (50)
+- 食神/傷官: 긍정 (70)
+- 正財/偏財: 긍정 (75)
+- 正官/偏官: 중립 (55)
+- 正印/偏印: 긍정 (65)
+
+### 1.3 의사코드
+
+```python
+def calculate_annual_luck(
+    profile_id: str,
+    year: int,
+    birth_data: dict,
+    current_decade: dict
+) -> dict:
+    """
+    연운 계산: 년주 + 대운 조합 → 십신/12운성/태세/점수
+    """
+    # 1. 년주 조회 (60갑자 순환)
+    year_pillar = get_year_pillar(year)  # 예: 2025 → 乙巳
+
+    # 2. 십신 계산
+    ten_god = calculate_ten_god(birth_data["day_stem"], year_pillar["stem"])
+    ten_god_ko = TEN_GOD_KO_MAP[ten_god]
+
+    # 3. 12운성 계산
+    life_stage = TwelveStageCalculator.calculate(
+        day_stem=birth_data["day_stem"],
+        branch=year_pillar["branch"]
+    )
+
+    # 4. 태세 (년지의 원소 + 본명과의 관계)
+    tai_sui = {
+        "branch": year_pillar["branch"],
+        "element": BRANCH_TO_ELEMENT[year_pillar["branch"]],
+        "conflict_with_birth": check_tai_sui_conflict(
+            year_branch=year_pillar["branch"],
+            birth_pillars=birth_data["pillars"]
+        )
+    }
+
+    # 5. 연운 점수
+    score = calculate_annual_score(
+        ten_god=ten_god,
+        life_stage=life_stage["stage"],
+        decade_pillar=current_decade["pillar"],
+        tai_sui=tai_sui
+    )
+
+    # 6. 태그 생성
+    tags = generate_tags(ten_god, tai_sui["conflict_with_birth"])
+
+    # 7. 주요 월 추천
+    key_months = recommend_key_months(year, score, tai_sui)
+
+    return {
+        "year": year,
+        "year_pillar": year_pillar,
+        "ten_god": ten_god,
+        "ten_god_ko": ten_god_ko,
+        "life_stage": life_stage["stage"],
+        "life_stage_ko": life_stage["stage_ko"],
+        "tai_sui": tai_sui,
+        "annual_score": score,
+        "tags": tags,
+        "summary": {
+            "strength": classify_strength(score),
+            "fortune": classify_fortune(score),
+            "key_months": key_months
+        }
+    }
+
+def get_year_pillar(year: int) -> dict:
+    """
+    년도 → 년주 60갑자 (1900년 기준 甲子 시작)
+    """
+    base_year = 1900
+    base_index = 36  # 1900 = 庚子 (36번째)
+    offset = (year - base_year) % 60
+    index = (base_index + offset) % 60
+
+    SIXTY_JIAZI = [
+        "甲子", "乙丑", "丙寅", "丁卯", "戊辰", "己巳", "庚午", "辛未", "壬申", "癸酉",
+        "甲戌", "乙亥", "丙子", "丁丑", "戊寅", "己卯", "庚辰", "辛巳", "壬午", "癸未",
+        # ... 60개
+    ]
+    sexagenary = SIXTY_JIAZI[index]
+    stem = sexagenary[0]
+    branch = sexagenary[1]
+
+    return {
+        "stem": stem,
+        "branch": branch,
+        "sexagenary": sexagenary,
+        "stem_ko": STEM_KO_MAP[stem],
+        "branch_ko": BRANCH_KO_MAP[branch],
+        "sexagenary_ko": SIXTY_JIAZI_KO_MAP[sexagenary]
+    }
+
+def check_tai_sui_conflict(year_branch: str, birth_pillars: dict) -> list:
+    """
+    태세와 본명 기둥의 충/형/해 검사
+    """
+    conflicts = []
+    birth_branches = [p["branch"] for p in birth_pillars.values()]
+
+    for birth_branch in birth_branches:
+        if (year_branch, birth_branch) in CHONG_PAIRS:
+            conflicts.append(f"{year_branch}{birth_branch}沖")
+        elif (year_branch, birth_branch) in XING_PAIRS:
+            conflicts.append(f"{year_branch}{birth_branch}刑")
+        elif (year_branch, birth_branch) in HAI_PAIRS:
+            conflicts.append(f"{year_branch}{birth_branch}害")
+
+    return conflicts
+```
+
+### 1.4 엣지 케이스
+
+1. **윤년 처리**: 2월 29일 출생자의 연운 계산 (2월 28일로 처리)
+2. **자시 전환**: 년 경계 (12/31 23:00~1/1 01:00) 태어난 경우 년주 결정 주의
+3. **대운 전환기**: 연 중간에 대운이 바뀌는 경우 (예: 7.98세 → 2025년 중 8세 도달)
+4. **태세 충**: 년지와 일지 충 (犯太歲) → 주의 태그 강조
+
+### 1.5 단위 테스트
+
+```python
+def test_annual_luck_calculator():
+    # Case 1: 2025년 연운 (乙巳년, 乙일간)
+    result = calculate_annual_luck(
+        profile_id="550e8400-e29b-41d4-a716-446655440000",
+        year=2025,
+        birth_data={
+            "day_stem": "乙",
+            "gender": "male",
+            "birth_dt": "2000-09-14T10:00:00+09:00",
+            "pillars": {
+                "year": {"branch": "辰"},
+                "month": {"branch": "酉"},
+                "day": {"branch": "亥"},
+                "hour": {"branch": "巳"}
+            }
+        },
+        current_decade={"pillar": "甲申", "start_age": 7.98, "direction": "reverse"}
+    )
+
+    assert result["year"] == 2025
+    assert result["year_pillar"]["sexagenary"] == "乙巳"
+    assert result["ten_god"] == "比肩"
+    assert result["life_stage"] == "病"
+    assert "巳亥沖" in result["tai_sui"]["conflict_with_birth"]
+    assert 60 <= result["annual_score"] <= 75
+
+    # Case 2: 2026년 연운 (丙午년)
+    result2 = calculate_annual_luck(
+        profile_id="550e8400-e29b-41d4-a716-446655440000",
+        year=2026,
+        birth_data={"day_stem": "乙", "pillars": {...}},
+        current_decade={"pillar": "甲申"}
+    )
+    assert result2["year_pillar"]["sexagenary"] == "丙午"
+    assert result2["ten_god"] == "傷官"
+```
+
+---
+
+## 2. MonthlyLuckCalculator 사양
+
+### 2.1 I/O JSON Schema
+
+**Input:**
+```json
+{
+  "profile_id": "550e8400-e29b-41d4-a716-446655440000",
+  "month": "2025-10",
+  "birth_data": {
+    "day_stem": "乙",
+    "pillars": {...}
+  },
+  "annual_luck": {
+    "year_pillar": "乙巳",
+    "annual_score": 68.5
+  }
+}
+```
+
+**Output:**
+```json
+{
+  "month": "2025-10",
+  "month_pillar": {
+    "stem": "丙",
+    "branch": "戌",
+    "sexagenary": "丙戌",
+    "stem_ko": "병",
+    "branch_ko": "술",
+    "sexagenary_ko": "병술"
+  },
+  "ten_god": "傷官",
+  "ten_god_ko": "상관",
+  "life_stage": "墓",
+  "life_stage_ko": "묘",
+  "monthly_score": 72.3,
+  "good_days": [3, 8, 13, 18, 23, 28],
+  "caution_days": [5, 14, 19, 27],
+  "daily_snippet": {
+    "range": "D+1~D+7",
+    "highlights": [
+      {"date": "2025-10-03", "tag": "문서정리", "score": 85},
+      {"date": "2025-10-08", "tag": "계약유리", "score": 82}
+    ]
+  },
+  "summary": {
+    "theme": "정리·지출관리",
+    "recommendation": "문서 정리 유리, 계약은 22일 이후",
+    "caution": "5일, 14일 갈등 주의"
+  }
+}
+```
+
+### 2.2 결정 규칙
+
+**월운 계산 흐름:**
+1. **월주 조회**: 해당 월의 천간/지지 결정 (예: 2025-10 = 丙戌)
+2. **십신 계산**: 일간 vs 월간 → 십신
+3. **12운성 계산**: 일간 + 월지 → 12운성
+4. **월운 점수**: 십신 + 12운성 + 연운 조합 → 0~100
+5. **길일/흉일 계산**: 일별 천간/지지 조합 → good_days/caution_days (1~31)
+6. **7일 티저**: D+1~D+7 상세 일정 (채팅 응답용)
+
+**길일/흉일 판단 기준:**
+- **길일**: 일간과 합/생조 관계, 12운성 강함 (長生/帝旺/臨官)
+- **흉일**: 일간과 충/극 관계, 12운성 약함 (死/墓/絶)
+
+**월주 계산 (절기 기반):**
+- 입춘(立春) ~ 경칩(驚蟄): 寅월 (인월, 1절기)
+- 경칩 ~ 청명(清明): 卯월 (묘월, 2절기)
+- ... 12개월 순환
+
+### 2.3 의사코드
+
+```python
+def calculate_monthly_luck(
+    profile_id: str,
+    month: str,  # "YYYY-MM"
+    birth_data: dict,
+    annual_luck: dict
+) -> dict:
+    """
+    월운 계산: 월주 + 길흉일 → 십신/12운성/good_days/caution_days
+    """
+    # 1. 월주 조회 (절기 기반)
+    month_pillar = get_month_pillar(month)  # 예: 2025-10 → 丙戌
+
+    # 2. 십신 계산
+    ten_god = calculate_ten_god(birth_data["day_stem"], month_pillar["stem"])
+
+    # 3. 12운성 계산
+    life_stage = TwelveStageCalculator.calculate(
+        day_stem=birth_data["day_stem"],
+        branch=month_pillar["branch"]
+    )
+
+    # 4. 월운 점수
+    score = calculate_monthly_score(
+        ten_god=ten_god,
+        life_stage=life_stage["stage"],
+        annual_score=annual_luck["annual_score"]
+    )
+
+    # 5. 길일/흉일 계산 (1~31일)
+    good_days, caution_days = calculate_daily_luck(
+        month=month,
+        day_stem=birth_data["day_stem"],
+        month_pillar=month_pillar
+    )
+
+    # 6. 7일 티저 생성
+    daily_snippet = generate_daily_snippet(
+        month=month,
+        good_days=good_days[:7],
+        ten_god=ten_god
+    )
+
+    # 7. 요약
+    summary = {
+        "theme": infer_theme(ten_god, life_stage["stage"]),
+        "recommendation": generate_recommendation(good_days),
+        "caution": generate_caution(caution_days)
+    }
+
+    return {
+        "month": month,
+        "month_pillar": month_pillar,
+        "ten_god": ten_god,
+        "ten_god_ko": TEN_GOD_KO_MAP[ten_god],
+        "life_stage": life_stage["stage"],
+        "life_stage_ko": life_stage["stage_ko"],
+        "monthly_score": score,
+        "good_days": good_days,
+        "caution_days": caution_days,
+        "daily_snippet": daily_snippet,
+        "summary": summary
+    }
+
+def get_month_pillar(month: str) -> dict:
+    """
+    월 → 월주 60갑자 (절기 기준)
+    """
+    year, month_num = month.split("-")
+    year = int(year)
+    month_num = int(month_num)
+
+    # 절기 기반 월지 결정
+    MONTH_BRANCHES = [
+        "寅", "卯", "辰", "巳", "午", "未",
+        "申", "酉", "戌", "亥", "子", "丑"
+    ]
+    branch = MONTH_BRANCHES[month_num - 1]
+
+    # 월간 결정 (년간 기준 순환)
+    year_stem = get_year_pillar(year)["stem"]
+    month_stem = calculate_month_stem(year_stem, month_num)
+
+    sexagenary = month_stem + branch
+
+    return {
+        "stem": month_stem,
+        "branch": branch,
+        "sexagenary": sexagenary,
+        "stem_ko": STEM_KO_MAP[month_stem],
+        "branch_ko": BRANCH_KO_MAP[branch],
+        "sexagenary_ko": SIXTY_JIAZI_KO_MAP.get(sexagenary, sexagenary)
+    }
+
+def calculate_month_stem(year_stem: str, month_num: int) -> str:
+    """
+    년간 + 월 → 월간 (오호기법)
+    """
+    MONTH_STEM_TABLE = {
+        "甲": ["丙", "丁", "戊", "己", "庚", "辛", "壬", "癸", "甲", "乙", "丙", "丁"],
+        "乙": ["戊", "己", "庚", "辛", "壬", "癸", "甲", "乙", "丙", "丁", "戊", "己"],
+        "丙": ["庚", "辛", "壬", "癸", "甲", "乙", "丙", "丁", "戊", "己", "庚", "辛"],
+        "丁": ["壬", "癸", "甲", "乙", "丙", "丁", "戊", "己", "庚", "辛", "壬", "癸"],
+        "戊": ["甲", "乙", "丙", "丁", "戊", "己", "庚", "辛", "壬", "癸", "甲", "乙"],
+        "己": ["丙", "丁", "戊", "己", "庚", "辛", "壬", "癸", "甲", "乙", "丙", "丁"],
+        "庚": ["戊", "己", "庚", "辛", "壬", "癸", "甲", "乙", "丙", "丁", "戊", "己"],
+        "辛": ["庚", "辛", "壬", "癸", "甲", "乙", "丙", "丁", "戊", "己", "庚", "辛"],
+        "壬": ["壬", "癸", "甲", "乙", "丙", "丁", "戊", "己", "庚", "辛", "壬", "癸"],
+        "癸": ["甲", "乙", "丙", "丁", "戊", "己", "庚", "辛", "壬", "癸", "甲", "乙"]
+    }
+    return MONTH_STEM_TABLE[year_stem][month_num - 1]
+
+def calculate_daily_luck(month: str, day_stem: str, month_pillar: dict) -> tuple:
+    """
+    일별 길흉 계산 (1~31일)
+    """
+    year, month_num = map(int, month.split("-"))
+    days_in_month = get_days_in_month(year, month_num)
+
+    good_days = []
+    caution_days = []
+
+    for day in range(1, days_in_month + 1):
+        day_pillar = get_day_pillar(year, month_num, day)
+        score = calculate_day_score(day_stem, day_pillar, month_pillar)
+
+        if score >= 75:
+            good_days.append(day)
+        elif score <= 40:
+            caution_days.append(day)
+
+    return good_days, caution_days
+```
+
+### 2.4 엣지 케이스
+
+1. **절기 경계**: 월 초/말 절기 전환 시 월주 변경 (예: 10/8 한로 이후 戌월)
+2. **2월 일수**: 윤년/평년 구분 (28일/29일)
+3. **길일 없음**: 월운 점수가 낮아 good_days가 0개인 경우 → "신중한 월" 태그
+4. **7일 티저**: 월 말일 경우 D+1~D+7이 다음 월로 넘어감 → 다음 월 데이터 필요
+
+### 2.5 단위 테스트
+
+```python
+def test_monthly_luck_calculator():
+    # Case 1: 2025-10 월운 (丙戌월, 乙일간)
+    result = calculate_monthly_luck(
+        profile_id="550e8400-e29b-41d4-a716-446655440000",
+        month="2025-10",
+        birth_data={"day_stem": "乙", "pillars": {...}},
+        annual_luck={"year_pillar": "乙巳", "annual_score": 68.5}
+    )
+
+    assert result["month"] == "2025-10"
+    assert result["month_pillar"]["sexagenary"] == "丙戌"
+    assert result["ten_god"] == "傷官"
+    assert result["life_stage"] == "墓"
+    assert len(result["good_days"]) >= 3
+    assert len(result["caution_days"]) >= 2
+    assert result["daily_snippet"]["range"] == "D+1~D+7"
+
+    # Case 2: 2월 윤년 처리
+    result2 = calculate_monthly_luck(
+        profile_id="550e8400-e29b-41d4-a716-446655440000",
+        month="2024-02",  # 윤년
+        birth_data={"day_stem": "乙"},
+        annual_luck={"annual_score": 70}
+    )
+    assert 29 in result2["good_days"] or 29 in result2["caution_days"]  # 2월 29일 포함
+
+    # Case 3: 길일 없음 (저조한 월)
+    result3 = calculate_monthly_luck(
+        profile_id="test",
+        month="2025-11",
+        birth_data={"day_stem": "甲"},
+        annual_luck={"annual_score": 35}
+    )
+    if len(result3["good_days"]) == 0:
+        assert "신중" in result3["summary"]["theme"]
+```
+
+---
+
+## 3. API 엔드포인트 스키마
+
+### 3.1 POST /api/v1/luck/annual
+
+**Request Schema:**
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://api.saju.example.com/schemas/luck_annual_request_v1.schema.json",
+  "type": "object",
+  "required": ["profile_id", "year"],
+  "properties": {
+    "profile_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "저장된 프로필 ID"
+    },
+    "year": {
+      "type": "integer",
+      "minimum": 1900,
+      "maximum": 2100,
+      "description": "조회 년도 (YYYY)"
+    }
+  }
+}
+```
+
+**Response Schema:**
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://api.saju.example.com/schemas/luck_annual_response_v1.schema.json",
+  "type": "object",
+  "required": ["year", "year_pillar", "ten_god", "life_stage", "annual_score", "summary"],
+  "properties": {
+    "year": {"type": "integer"},
+    "year_pillar": {"$ref": "#/$defs/Pillar"},
+    "ten_god": {"type": "string", "enum": ["比肩", "劫財", "食神", "傷官", "正財", "偏財", "正官", "偏官", "正印", "偏印"]},
+    "ten_god_ko": {"type": "string"},
+    "life_stage": {"type": "string", "enum": ["長生", "沐浴", "冠帶", "臨官", "帝旺", "衰", "病", "死", "墓", "絶", "胎", "養"]},
+    "life_stage_ko": {"type": "string"},
+    "tai_sui": {
+      "type": "object",
+      "properties": {
+        "branch": {"type": "string"},
+        "element": {"type": "string"},
+        "conflict_with_birth": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "annual_score": {"type": "number", "minimum": 0, "maximum": 100},
+    "tags": {"type": "array", "items": {"type": "string"}},
+    "summary": {
+      "type": "object",
+      "properties": {
+        "strength": {"type": "string", "enum": ["strong", "neutral", "weak"]},
+        "fortune": {"type": "string", "enum": ["excellent", "good", "neutral", "caution", "difficult"]},
+        "key_months": {"type": "array", "items": {"type": "string", "pattern": "^\\d{4}-\\d{2}$"}}
+      }
+    },
+    "signatures": {
+      "type": "object",
+      "properties": {
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+      }
+    }
+  }
+}
+```
+
+### 3.2 POST /api/v1/luck/monthly
+
+**Request Schema:**
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://api.saju.example.com/schemas/luck_monthly_request_v1.schema.json",
+  "type": "object",
+  "required": ["profile_id", "month"],
+  "properties": {
+    "profile_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "month": {
+      "type": "string",
+      "pattern": "^\\d{4}-(0[1-9]|1[0-2])$",
+      "description": "조회 월 (YYYY-MM)"
+    }
+  }
+}
+```
+
+**Response Schema:**
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://api.saju.example.com/schemas/luck_monthly_response_v1.schema.json",
+  "type": "object",
+  "required": ["month", "month_pillar", "ten_god", "life_stage", "monthly_score", "good_days", "caution_days", "summary"],
+  "properties": {
+    "month": {"type": "string", "pattern": "^\\d{4}-(0[1-9]|1[0-2])$"},
+    "month_pillar": {"$ref": "#/$defs/Pillar"},
+    "ten_god": {"type": "string"},
+    "ten_god_ko": {"type": "string"},
+    "life_stage": {"type": "string"},
+    "life_stage_ko": {"type": "string"},
+    "monthly_score": {"type": "number", "minimum": 0, "maximum": 100},
+    "good_days": {"type": "array", "items": {"type": "integer", "minimum": 1, "maximum": 31}},
+    "caution_days": {"type": "array", "items": {"type": "integer", "minimum": 1, "maximum": 31}},
+    "daily_snippet": {
+      "type": "object",
+      "properties": {
+        "range": {"type": "string"},
+        "highlights": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "date": {"type": "string", "format": "date"},
+              "tag": {"type": "string"},
+              "score": {"type": "number"}
+            }
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "properties": {
+        "theme": {"type": "string"},
+        "recommendation": {"type": "string"},
+        "caution": {"type": "string"}
+      }
+    },
+    "signatures": {
+      "type": "object",
+      "properties": {
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+      }
+    }
+  }
+}
+```
+
+---
+
+## 4. 캐시 전략
+
+### 4.1 캐시 키 구조
+
+**연운 캐시:**
+```
+cache_key = f"luck:annual:{profile_id}:{year}"
+ttl = 365 days
+```
+
+**월운 캐시:**
+```
+cache_key = f"luck:monthly:{profile_id}:{month}"
+ttl = 30 days
+```
+
+**RFC-8785 서명:**
+```python
+canonical = canonicalize(response_data)  # RFC-8785
+sha256 = hashlib.sha256(canonical).hexdigest()
+response["signatures"] = {"sha256": sha256}
+```
+
+### 4.2 무효화 규칙
+
+**연운 무효화:**
+- 프로필 수정 시 (pillars/birth_dt 변경)
+- 대운 재계산 시 (LuckCalculator 호출)
+
+**월운 무효화:**
+- 프로필 수정 시
+- 연운 재계산 시 (연운 점수가 월운에 영향)
+
+**프리페치:**
+- 현재 년도 ±1년 연운 미리 계산 (배경 작업)
+- 현재 월 ±1개월 월운 미리 계산
+
+### 4.3 캐시 검증
+
+```python
+def get_annual_luck_cached(profile_id: str, year: int) -> dict:
+    cache_key = f"luck:annual:{profile_id}:{year}"
+    cached = redis.get(cache_key)
+
+    if cached:
+        data = json.loads(cached)
+        # RFC-8785 서명 검증
+        canonical = canonicalize({k: v for k, v in data.items() if k != "signatures"})
+        computed_hash = hashlib.sha256(canonical).hexdigest()
+        if computed_hash == data["signatures"]["sha256"]:
+            return data
+
+    # 캐시 미스 → 계산
+    result = calculate_annual_luck(profile_id, year, ...)
+    redis.setex(cache_key, 365 * 86400, json.dumps(result))
+    return result
+```
+
+---
+
+## 5. 통합 체크리스트
+
+### Phase 1: 엔진 구현
+- [ ] AnnualLuckCalculator 구현 (년주 조회/십신/12운성/태세/점수)
+- [ ] MonthlyLuckCalculator 구현 (월주 조회/일별 길흉/7일 티저)
+- [ ] get_year_pillar() 구현 (60갑자 순환)
+- [ ] get_month_pillar() 구현 (절기 기반 월주)
+- [ ] calculate_day_score() 구현 (일별 점수)
+
+### Phase 2: API 통합
+- [ ] POST /api/v1/luck/annual 엔드포인트 구현
+- [ ] POST /api/v1/luck/monthly 엔드포인트 구현
+- [ ] 캐시 레이어 통합 (Redis)
+- [ ] RFC-8785 서명 생성/검증
+
+### Phase 3: 테스트
+- [ ] test_annual_luck_calculator.py (4 케이스)
+- [ ] test_monthly_luck_calculator.py (5 케이스)
+- [ ] 통합 테스트: API → 엔진 → 캐시 플로우
+- [ ] 성능 테스트: P95 <500ms (캐시 히트), <2s (캐시 미스)
+
+### Phase 4: 채팅 통합
+- [ ] /chat/send에서 luck_snippet 카드 생성 (MonthlyLuckCalculator.daily_snippet 사용)
+- [ ] intent=month/year 시 연/월운 데이터 로드
+- [ ] next_cta에 "이번 달 달력 보기", "연운 타임라인" 추가
+
+### Phase 5: 문서화
+- [ ] luck_pillars_policy.json 확장 (연/월운 점수 공식)
+- [ ] localization_ko_v1.json 태그 추가 (예: "比肩年", "巳亥沖")
+- [ ] API 문서 업데이트 (OpenAPI 스펙)
+
+---
+
+**Version:** v1.0 (2025-10-07 KST)
+**Maintainer:** Core Architects (Policy/Engine/Data)

--- a/docs/policy-prompts/20_policy-engines/twelve_stage_void_yuanjin_combo_prompt.md
+++ b/docs/policy-prompts/20_policy-engines/twelve_stage_void_yuanjin_combo_prompt.md
@@ -1,0 +1,845 @@
+# 📘 실행 프롬프트 — 12운성/공망/원진/합화오행 엔진 스펙 v1.0
+
+**버전**: v1.0
+**날짜**: 2025-10-07 KST
+**경로 권장**: `docs/policy-prompts/20_policy-engines/twelve_stage_void_yuanjin_combo_prompt.md`
+
+---
+
+## ROLE
+너는 KO-first 정책/엔진 아키텍트다. 설명 대신 **결정적 산출물**만 출력한다.
+
+## GOAL
+**4개 엔진**의 완전한 사양을 산출한다:
+1. **TwelveStageCalculator** (12운성: 장생~양 12단계)
+2. **VoidCalculator** (공망: 일간 기준 공망 지지)
+3. **YuanjinDetector** (원진: 지지 원진 관계)
+4. **CombinationElementTransformer** (합화오행: 합화 결과 원소)
+
+각 엔진별 **I/O JSON Schema, 결정 규칙표, 의사코드, 엣지 케이스, 단위 테스트 명세**를 포함한다.
+
+## CONTEXT (고정 사실)
+- **12운성 (Twelve Life Stages)**: 일간 + 지지 → 장생/沐浴/冠帶/臨官/帝旺/衰/病/死/墓/絶/胎/養 (12단계)
+- **공망 (Void/Empty)**: 일주 60갑자 → 해당 순환의 마지막 2지지가 공망 (예: 甲子순 → 戌亥공망)
+- **원진 (Yuanjin/元辰)**: 지지 간 원진 관계 (子未, 丑午, 寅巳, 卯辰, 申亥, 酉戌)
+- **합화오행 (Combination Element)**: 천간 합 → 화합 원소 (甲己合土, 乙庚合金, 丙辛合水, 丁壬合木, 戊癸合火), 지지 삼합 → 국 형성 (申子辰水局 등)
+- 기존 정책: `lifecycle_stages.json` (12운성 매핑 존재), `relation_policy.json` (원진/합화 확장 필요)
+- KO-first 라벨: `*_ko` 병행 (예: `stage:"長生"`, `stage_ko:"장생"`)
+
+## OUTPUT ORDER (반드시 이 순서)
+1) 문서 헤더 (제목/버전/날짜)
+2) **TwelveStageCalculator 사양** (I/O Schema, 결정 규칙표, 의사코드, 엣지 케이스, 테스트)
+3) **VoidCalculator 사양** (I/O Schema, 공망표, 의사코드, 엣지 케이스, 테스트)
+4) **YuanjinDetector 사양** (I/O Schema, 원진쌍, 의사코드, 엣지 케이스, 테스트)
+5) **CombinationElementTransformer 사양** (I/O Schema, 합화 규칙표, 의사코드, 엣지 케이스, 테스트)
+6) **relation_policy.json 확장 예시** (원진/합화 필드 추가)
+7) **localization_ko_v1.json 확장** (라벨 20개+ 추가 목록)
+8) **통합 체크리스트** (정책 파일/엔진 통합/테스트)
+
+---
+
+## 1. TwelveStageCalculator 사양
+
+### 1.1 I/O JSON Schema
+
+**Input:**
+```json
+{
+  "day_stem": "乙",
+  "branches": ["辰", "酉", "亥", "巳"]
+}
+```
+
+**Output:**
+```json
+{
+  "by_pillar": {
+    "year": "墓",
+    "month": "死",
+    "day": "帝旺",
+    "hour": "病"
+  },
+  "by_pillar_ko": {
+    "year": "묘",
+    "month": "사",
+    "day": "제왕",
+    "hour": "병"
+  },
+  "summary": {
+    "strong_stages": ["帝旺"],
+    "weak_stages": ["死", "病", "墓"],
+    "balance": "weak_majority"
+  }
+}
+```
+
+### 1.2 결정 규칙표 (12운성)
+
+**일간별 12운성 매핑 (lifecycle_stages.json 기반):**
+
+| 일간 | 長生 | 沐浴 | 冠帶 | 臨官 | 帝旺 | 衰 | 病 | 死 | 墓 | 絶 | 胎 | 養 |
+|------|------|------|------|------|------|-----|-----|-----|-----|-----|-----|-----|
+| 甲 (양목) | 亥 | 子 | 丑 | 寅 | 卯 | 辰 | 巳 | 午 | 未 | 申 | 酉 | 戌 |
+| 乙 (음목) | 午 | 巳 | 辰 | 卯 | 寅 | 丑 | 子 | 亥 | 戌 | 酉 | 申 | 未 |
+| 丙 (양화) | 寅 | 卯 | 辰 | 巳 | 午 | 未 | 申 | 酉 | 戌 | 亥 | 子 | 丑 |
+| 丁 (음화) | 酉 | 申 | 未 | 午 | 巳 | 辰 | 卯 | 寅 | 丑 | 子 | 亥 | 戌 |
+| 戊 (양토) | 寅 | 卯 | 辰 | 巳 | 午 | 未 | 申 | 酉 | 戌 | 亥 | 子 | 丑 |
+| 己 (음토) | 酉 | 申 | 未 | 午 | 巳 | 辰 | 卯 | 寅 | 丑 | 子 | 亥 | 戌 |
+| 庚 (양금) | 巳 | 午 | 未 | 申 | 酉 | 戌 | 亥 | 子 | 丑 | 寅 | 卯 | 辰 |
+| 辛 (음금) | 子 | 亥 | 戌 | 酉 | 申 | 未 | 午 | 巳 | 辰 | 卯 | 寅 | 丑 |
+| 壬 (양수) | 申 | 酉 | 戌 | 亥 | 子 | 丑 | 寅 | 卯 | 辰 | 巳 | 午 | 未 |
+| 癸 (음수) | 卯 | 寅 | 丑 | 子 | 亥 | 戌 | 酉 | 申 | 未 | 午 | 巳 | 辰 |
+
+**강약 분류:**
+- **강 (Strong)**: 長生, 冠帶, 臨官, 帝旺
+- **중 (Neutral)**: 養, 沐浴
+- **약 (Weak)**: 衰, 病, 死, 墓, 絶, 胎
+
+### 1.3 의사코드
+
+```python
+def calculate_twelve_stage(day_stem: str, branch: str) -> dict:
+    """
+    일간 + 지지 → 12운성 단계
+    """
+    # lifecycle_stages.json 로드
+    stages_map = load_policy("lifecycle_stages.json")
+
+    # 일간별 12운성 순환 테이블 조회
+    cycle = stages_map[day_stem]  # ['亥', '子', '丑', ...]
+
+    # 지지 위치 찾기
+    if branch not in cycle:
+        return {"stage": None, "stage_ko": None}
+
+    index = cycle.index(branch)
+    stage_names = ["長生", "沐浴", "冠帶", "臨官", "帝旺", "衰", "病", "死", "墓", "絶", "胎", "養"]
+    stage = stage_names[index]
+
+    # 한국어 라벨
+    stage_ko = STAGE_KO_MAP[stage]  # localization_ko_v1.json
+
+    return {
+        "stage": stage,
+        "stage_ko": stage_ko,
+        "strength": classify_strength(stage)  # strong/neutral/weak
+    }
+
+def calculate_all_pillars(day_stem: str, pillars: dict) -> dict:
+    """
+    4개 기둥에 대한 12운성 계산
+    """
+    result = {
+        "by_pillar": {},
+        "by_pillar_ko": {},
+        "summary": {}
+    }
+
+    for pillar_name in ["year", "month", "day", "hour"]:
+        branch = pillars[pillar_name]["branch"]
+        stage_data = calculate_twelve_stage(day_stem, branch)
+        result["by_pillar"][pillar_name] = stage_data["stage"]
+        result["by_pillar_ko"][pillar_name] = stage_data["stage_ko"]
+
+    # 요약
+    all_stages = list(result["by_pillar"].values())
+    strong = [s for s in all_stages if s in ["長生", "冠帶", "臨官", "帝旺"]]
+    weak = [s for s in all_stages if s in ["衰", "病", "死", "墓", "絶", "胎"]]
+
+    result["summary"] = {
+        "strong_stages": strong,
+        "weak_stages": weak,
+        "balance": "strong_majority" if len(strong) > len(weak) else "weak_majority"
+    }
+
+    return result
+```
+
+### 1.4 엣지 케이스
+
+1. **일간 음양 구분**: 乙(음목)과 甲(양목)은 순환 방향이 다름 → 테이블 정확성 검증 필수
+2. **공망 지지**: 공망 지지도 12운성 계산 대상 (공망 여부는 VoidCalculator가 별도 처리)
+3. **시간 미상 (unknown_hour)**: `pillars.hour = null` 시 해당 기둥 12운성도 null
+4. **요약 balance**: 강약 동수일 때 "balanced" 처리
+
+### 1.5 단위 테스트
+
+```python
+def test_twelve_stage_calculator():
+    # Case 1: 乙木 + 亥 → 帝旺
+    assert calculate_twelve_stage("乙", "亥") == {
+        "stage": "帝旺",
+        "stage_ko": "제왕",
+        "strength": "strong"
+    }
+
+    # Case 2: 庚金 + 巳 → 長生
+    assert calculate_twelve_stage("庚", "巳") == {
+        "stage": "長生",
+        "stage_ko": "장생",
+        "strength": "strong"
+    }
+
+    # Case 3: 癸水 + 卯 → 長生
+    assert calculate_twelve_stage("癸", "卯") == {
+        "stage": "長生",
+        "stage_ko": "장생",
+        "strength": "strong"
+    }
+
+    # Case 4: 甲木 + 申 → 絶
+    assert calculate_twelve_stage("甲", "申") == {
+        "stage": "絶",
+        "stage_ko": "절",
+        "strength": "weak"
+    }
+
+    # Case 5: 4 pillars (乙亥, 庚辰, 乙酉, 辛巳)
+    result = calculate_all_pillars("乙", {
+        "year": {"branch": "辰"},
+        "month": {"branch": "酉"},
+        "day": {"branch": "亥"},
+        "hour": {"branch": "巳"}
+    })
+    assert result["by_pillar"]["year"] == "墓"
+    assert result["by_pillar"]["day"] == "帝旺"
+    assert result["summary"]["balance"] == "weak_majority"
+```
+
+---
+
+## 2. VoidCalculator 사양
+
+### 2.1 I/O JSON Schema
+
+**Input:**
+```json
+{
+  "day_pillar": "乙亥"
+}
+```
+
+**Output:**
+```json
+{
+  "kong_wang": ["戌", "亥"],
+  "kong_wang_ko": ["술", "해"],
+  "affected_pillars": ["day"],
+  "severity": "high"
+}
+```
+
+### 2.2 공망표 (60갑자 순환)
+
+**10개 순환 × 6회 = 60갑자:**
+
+| 순환 | 갑자 범위 | 공망 지지 |
+|------|-----------|----------|
+| 1 | 甲子~癸酉 (10개) | 戌, 亥 |
+| 2 | 甲戌~癸未 (10개) | 申, 酉 |
+| 3 | 甲申~癸巳 (10개) | 午, 未 |
+| 4 | 甲午~癸卯 (10개) | 辰, 巳 |
+| 5 | 甲辰~癸丑 (10개) | 寅, 卯 |
+| 6 | 甲寅~癸亥 (10개) | 子, 丑 |
+
+**예시:**
+- 甲子일주 → 1순환 → 戌亥공망
+- 乙亥일주 → 1순환 → 戌亥공망
+- 甲戌일주 → 2순환 → 申酉공망
+- 甲午일주 → 4순환 → 辰巳공망
+
+### 2.3 의사코드
+
+```python
+def calculate_void(day_pillar: str) -> dict:
+    """
+    일주 60갑자 → 공망 지지 2개
+    """
+    VOID_TABLE = {
+        # 순환 1: 甲子~癸酉
+        "甲子": ["戌", "亥"], "乙丑": ["戌", "亥"], "丙寅": ["戌", "亥"],
+        "丁卯": ["戌", "亥"], "戊辰": ["戌", "亥"], "己巳": ["戌", "亥"],
+        "庚午": ["戌", "亥"], "辛未": ["戌", "亥"], "壬申": ["戌", "亥"],
+        "癸酉": ["戌", "亥"],
+
+        # 순환 2: 甲戌~癸未
+        "甲戌": ["申", "酉"], "乙亥": ["戌", "亥"], "丙子": ["戌", "亥"],
+        # ... (전체 60갑자 매핑)
+    }
+
+    kong_wang = VOID_TABLE.get(day_pillar, [])
+    kong_wang_ko = [BRANCH_KO_MAP[b] for b in kong_wang]
+
+    return {
+        "kong_wang": kong_wang,
+        "kong_wang_ko": kong_wang_ko
+    }
+
+def check_void_in_pillars(day_pillar: str, pillars: dict) -> dict:
+    """
+    4개 기둥 중 공망 지지가 있는지 확인
+    """
+    void_data = calculate_void(day_pillar)
+    kong_wang = set(void_data["kong_wang"])
+
+    affected = []
+    for pillar_name in ["year", "month", "day", "hour"]:
+        branch = pillars[pillar_name]["branch"]
+        if branch in kong_wang:
+            affected.append(pillar_name)
+
+    severity = "high" if "day" in affected or len(affected) >= 2 else "low"
+
+    return {
+        "kong_wang": void_data["kong_wang"],
+        "kong_wang_ko": void_data["kong_wang_ko"],
+        "affected_pillars": affected,
+        "severity": severity
+    }
+```
+
+### 2.4 엣지 케이스
+
+1. **일주만 기준**: 공망은 일주 기준 (년/월/시주 무관)
+2. **일주 자체가 공망**: 예: 乙亥일주 → 戌亥공망 → 일지 亥가 공망에 포함 (severity=high)
+3. **60갑자 완전 매핑**: VOID_TABLE이 60개 전체 커버하는지 검증
+4. **시간 미상**: `pillars.hour = null` 시 affected_pillars에서 hour 제외
+
+### 2.5 단위 테스트
+
+```python
+def test_void_calculator():
+    # Case 1: 甲子일주 → 戌亥공망
+    assert calculate_void("甲子") == {
+        "kong_wang": ["戌", "亥"],
+        "kong_wang_ko": ["술", "해"]
+    }
+
+    # Case 2: 乙亥일주 → 戌亥공망 (일지 자체가 공망)
+    result = check_void_in_pillars("乙亥", {
+        "year": {"branch": "辰"},
+        "month": {"branch": "酉"},
+        "day": {"branch": "亥"},
+        "hour": {"branch": "巳"}
+    })
+    assert result["affected_pillars"] == ["day"]
+    assert result["severity"] == "high"
+
+    # Case 3: 甲戌일주 → 申酉공망
+    assert calculate_void("甲戌") == {
+        "kong_wang": ["申", "酉"],
+        "kong_wang_ko": ["신", "유"]
+    }
+
+    # Case 4: 공망 없음
+    result = check_void_in_pillars("甲子", {
+        "year": {"branch": "子"},
+        "month": {"branch": "丑"},
+        "day": {"branch": "寅"},
+        "hour": {"branch": "卯"}
+    })
+    assert result["affected_pillars"] == []
+    assert result["severity"] == "low"
+```
+
+---
+
+## 3. YuanjinDetector 사양
+
+### 3.1 I/O JSON Schema
+
+**Input:**
+```json
+{
+  "branches": ["辰", "酉", "亥", "巳"]
+}
+```
+
+**Output:**
+```json
+{
+  "yuanjin_pairs": [],
+  "count": 0,
+  "affected_pillars": []
+}
+```
+
+### 3.2 원진쌍 (6쌍)
+
+| 원진쌍 | 설명 |
+|--------|------|
+| 子 ↔ 未 | 자미원진 |
+| 丑 ↔ 午 | 축오원진 |
+| 寅 ↔ 巳 | 인사원진 |
+| 卯 ↔ 辰 | 묘진원진 |
+| 申 ↔ 亥 | 신해원진 |
+| 酉 ↔ 戌 | 유술원진 |
+
+**특징:**
+- 원진은 **불화·마찰·장애** 의미 (충보다 약하지만 지속적)
+- 지지 간 관계이므로 천간 무관
+
+### 3.3 의사코드
+
+```python
+def detect_yuanjin(branches: list) -> dict:
+    """
+    지지 목록에서 원진 쌍 탐지
+    """
+    YUANJIN_PAIRS = {
+        ("子", "未"), ("未", "子"),
+        ("丑", "午"), ("午", "丑"),
+        ("寅", "巳"), ("巳", "寅"),
+        ("卯", "辰"), ("辰", "卯"),
+        ("申", "亥"), ("亥", "申"),
+        ("酉", "戌"), ("戌", "酉")
+    }
+
+    yuanjin_found = []
+    pillar_names = ["year", "month", "day", "hour"]
+
+    for i in range(len(branches)):
+        for j in range(i+1, len(branches)):
+            if (branches[i], branches[j]) in YUANJIN_PAIRS:
+                yuanjin_found.append([branches[i], branches[j]])
+
+    return {
+        "yuanjin_pairs": yuanjin_found,
+        "count": len(yuanjin_found),
+        "affected_pillars": []  # TODO: 구체적 기둥 위치 추적
+    }
+```
+
+### 3.4 엣지 케이스
+
+1. **원진 중복**: 동일 지지 2개 이상 시 조합 수 증가 (예: 子子未 → 원진 2쌍)
+2. **원진 + 충 동시**: 원진과 충이 같은 사주에 공존 가능 (예: 子未원진 + 巳亥충)
+3. **시간 미상**: `pillars.hour = null` 시 3개 지지만 검사
+4. **우선순위**: relation_policy.json에서 원진 우선순위는 충/형 다음
+
+### 3.5 단위 테스트
+
+```python
+def test_yuanjin_detector():
+    # Case 1: 子未 원진
+    assert detect_yuanjin(["子", "未", "寅", "卯"]) == {
+        "yuanjin_pairs": [["子", "未"]],
+        "count": 1
+    }
+
+    # Case 2: 원진 없음
+    assert detect_yuanjin(["辰", "酉", "亥", "巳"]) == {
+        "yuanjin_pairs": [],
+        "count": 0
+    }
+
+    # Case 3: 寅巳 원진
+    assert detect_yuanjin(["寅", "巳", "申", "亥"]) == {
+        "yuanjin_pairs": [["寅", "巳"], ["申", "亥"]],
+        "count": 2
+    }
+
+    # Case 4: 卯辰 원진
+    assert detect_yuanjin(["卯", "辰", "酉", "戌"]) == {
+        "yuanjin_pairs": [["卯", "辰"], ["酉", "戌"]],
+        "count": 2
+    }
+```
+
+---
+
+## 4. CombinationElementTransformer 사양
+
+### 4.1 I/O JSON Schema
+
+**Input:**
+```json
+{
+  "stems": ["庚", "乙", "乙", "辛"],
+  "branches": ["辰", "酉", "亥", "巳"]
+}
+```
+
+**Output:**
+```json
+{
+  "heavenly_combine": [
+    {
+      "pair": ["庚", "乙"],
+      "result": "金",
+      "pillars": ["year", "month"]
+    }
+  ],
+  "earth_sanhe": [],
+  "earth_he6": [
+    {
+      "pair": ["辰", "酉"],
+      "result": "金",
+      "pillars": ["year", "month"]
+    }
+  ],
+  "boost_elements": ["金"]
+}
+```
+
+### 4.2 합화 규칙표
+
+**천간 합화 (5쌍):**
+
+| 천간 쌍 | 화합 원소 | 조건 |
+|---------|-----------|------|
+| 甲 + 己 | 土 | 무조건 화합 |
+| 乙 + 庚 | 金 | 무조건 화합 |
+| 丙 + 辛 | 水 | 무조건 화합 |
+| 丁 + 壬 | 木 | 무조건 화합 |
+| 戊 + 癸 | 火 | 무조건 화합 |
+
+**지지 삼합 (4국):**
+
+| 삼합 | 화합 원소 | 조건 |
+|------|-----------|------|
+| 申子辰 | 水 | 3지지 모두 존재 |
+| 亥卯未 | 木 | 3지지 모두 존재 |
+| 寅午戌 | 火 | 3지지 모두 존재 |
+| 巳酉丑 | 金 | 3지지 모두 존재 |
+
+**지지 육합 (6쌍):**
+
+| 육합 쌍 | 화합 원소 |
+|---------|-----------|
+| 子 + 丑 | 土 |
+| 寅 + 亥 | 木 |
+| 卯 + 戌 | 火 |
+| 辰 + 酉 | 金 |
+| 巳 + 申 | 水 |
+| 午 + 未 | 火/土 (혼합) |
+
+### 4.3 의사코드
+
+```python
+def transform_combination_elements(stems: list, branches: list) -> dict:
+    """
+    천간 합화 + 지지 삼합/육합 → 화합 원소
+    """
+    HEAVENLY_COMBINE = {
+        frozenset(["甲", "己"]): "土",
+        frozenset(["乙", "庚"]): "金",
+        frozenset(["丙", "辛"]): "水",
+        frozenset(["丁", "壬"]): "木",
+        frozenset(["戊", "癸"]): "火"
+    }
+
+    EARTH_HE6 = {
+        frozenset(["子", "丑"]): "土",
+        frozenset(["寅", "亥"]): "木",
+        frozenset(["卯", "戌"]): "火",
+        frozenset(["辰", "酉"]): "金",
+        frozenset(["巳", "申"]): "水",
+        frozenset(["午", "未"]): "火"
+    }
+
+    EARTH_SANHE = {
+        frozenset(["申", "子", "辰"]): "水",
+        frozenset(["亥", "卯", "未"]): "木",
+        frozenset(["寅", "午", "戌"]): "火",
+        frozenset(["巳", "酉", "丑"]): "金"
+    }
+
+    result = {
+        "heavenly_combine": [],
+        "earth_sanhe": [],
+        "earth_he6": [],
+        "boost_elements": []
+    }
+
+    # 천간 합화
+    for i in range(len(stems)):
+        for j in range(i+1, len(stems)):
+            pair_set = frozenset([stems[i], stems[j]])
+            if pair_set in HEAVENLY_COMBINE:
+                element = HEAVENLY_COMBINE[pair_set]
+                result["heavenly_combine"].append({
+                    "pair": [stems[i], stems[j]],
+                    "result": element,
+                    "pillars": [get_pillar_name(i), get_pillar_name(j)]
+                })
+                result["boost_elements"].append(element)
+
+    # 지지 육합
+    for i in range(len(branches)):
+        for j in range(i+1, len(branches)):
+            pair_set = frozenset([branches[i], branches[j]])
+            if pair_set in EARTH_HE6:
+                element = EARTH_HE6[pair_set]
+                result["earth_he6"].append({
+                    "pair": [branches[i], branches[j]],
+                    "result": element,
+                    "pillars": [get_pillar_name(i), get_pillar_name(j)]
+                })
+                result["boost_elements"].append(element)
+
+    # 지지 삼합
+    branch_set = frozenset(branches)
+    for sanhe_set, element in EARTH_SANHE.items():
+        if sanhe_set.issubset(branch_set):
+            result["earth_sanhe"].append({
+                "triple": list(sanhe_set),
+                "result": element
+            })
+            result["boost_elements"].append(element)
+
+    # 중복 제거
+    result["boost_elements"] = list(set(result["boost_elements"]))
+
+    return result
+```
+
+### 4.4 엣지 케이스
+
+1. **午未 합**: 午未 합은 火/土 혼합 → 강한 쪽 선택 (컨텍스트 의존)
+2. **삼합 불완전**: 申子 있지만 辰 없음 → 삼합 미성립, 육합만 검사
+3. **합화 + 충 동시**: 辰酉합금 + 巳亥충 공존 시 우선순위는 충 (relation_policy.json)
+4. **boost_elements**: 합화로 강화되는 오행 목록 (wuxing.adjusted.percent에 반영)
+
+### 4.5 단위 테스트
+
+```python
+def test_combination_element_transformer():
+    # Case 1: 乙庚合金 (천간)
+    result = transform_combination_elements(
+        stems=["庚", "乙", "乙", "辛"],
+        branches=["辰", "酉", "亥", "巳"]
+    )
+    assert len(result["heavenly_combine"]) == 1
+    assert result["heavenly_combine"][0]["result"] == "金"
+
+    # Case 2: 辰酉合금 (육합)
+    assert len(result["earth_he6"]) == 1
+    assert result["earth_he6"][0]["result"] == "金"
+
+    # Case 3: 申子辰 삼합수국
+    result2 = transform_combination_elements(
+        stems=["甲", "乙", "丙", "丁"],
+        branches=["申", "子", "辰", "午"]
+    )
+    assert len(result2["earth_sanhe"]) == 1
+    assert result2["earth_sanhe"][0]["result"] == "水"
+
+    # Case 4: boost_elements 중복 제거
+    assert "金" in result["boost_elements"]
+    assert len(result["boost_elements"]) == 1  # 중복 제거
+```
+
+---
+
+## 5. relation_policy.json 확장 예시
+
+**기존 구조 + 원진/합화 추가:**
+
+```json
+{
+  "version": "2.1",
+  "heavenly": {
+    "combine": [
+      {
+        "pair": ["甲", "己"],
+        "result": "土",
+        "priority": 1,
+        "transform": true
+      },
+      {
+        "pair": ["乙", "庚"],
+        "result": "金",
+        "priority": 1,
+        "transform": true
+      }
+    ],
+    "clash": [
+      {
+        "pair": ["甲", "庚"],
+        "severity": "medium"
+      }
+    ]
+  },
+  "earth": {
+    "he6": [
+      {
+        "pair": ["子", "丑"],
+        "result": "土",
+        "transform": true
+      },
+      {
+        "pair": ["辰", "酉"],
+        "result": "金",
+        "transform": true
+      }
+    ],
+    "sanhe": [
+      {
+        "triple": ["申", "子", "辰"],
+        "result": "水",
+        "transform": true
+      },
+      {
+        "triple": ["亥", "卯", "未"],
+        "result": "木",
+        "transform": true
+      }
+    ],
+    "chong": [
+      {
+        "pair": ["子", "午"],
+        "severity": "high"
+      }
+    ],
+    "xing": [
+      {
+        "triple": ["寅", "巳", "申"],
+        "severity": "medium"
+      }
+    ],
+    "po": [
+      {
+        "pair": ["子", "酉"],
+        "severity": "low"
+      }
+    ],
+    "hai": [
+      {
+        "pair": ["子", "未"],
+        "severity": "low"
+      }
+    ],
+    "yuanjin": [
+      {
+        "pair": ["子", "未"],
+        "severity": "low",
+        "description": "원진 (元辰) - 불화·장애"
+      },
+      {
+        "pair": ["丑", "午"],
+        "severity": "low"
+      },
+      {
+        "pair": ["寅", "巳"],
+        "severity": "low"
+      },
+      {
+        "pair": ["卯", "辰"],
+        "severity": "low"
+      },
+      {
+        "pair": ["申", "亥"],
+        "severity": "low"
+      },
+      {
+        "pair": ["酉", "戌"],
+        "severity": "low"
+      }
+    ]
+  },
+  "priority": ["sanhe", "he6", "chong", "xing", "po", "hai", "yuanjin"],
+  "signature": {
+    "sha256": "..."
+  }
+}
+```
+
+---
+
+## 6. localization_ko_v1.json 확장
+
+**추가 라벨 20개+:**
+
+```json
+{
+  "version": "1.1",
+  "locale": "ko",
+  "mappings": {
+    "twelve_stages": {
+      "長生": "장생",
+      "沐浴": "목욕",
+      "冠帶": "관대",
+      "臨官": "임관",
+      "帝旺": "제왕",
+      "衰": "쇠",
+      "病": "병",
+      "死": "사",
+      "墓": "묘",
+      "絶": "절",
+      "胎": "태",
+      "養": "양"
+    },
+    "void": {
+      "kong_wang": "공망",
+      "empty": "공허",
+      "void_severity_high": "높음",
+      "void_severity_low": "낮음"
+    },
+    "yuanjin": {
+      "원진": "원진",
+      "子未": "자미원진",
+      "丑午": "축오원진",
+      "寅巳": "인사원진",
+      "卯辰": "묘진원진",
+      "申亥": "신해원진",
+      "酉戌": "유술원진"
+    },
+    "combination_elements": {
+      "甲己合土": "갑기합토",
+      "乙庚合金": "을경합금",
+      "丙辛合水": "병신합수",
+      "丁壬合木": "정임합목",
+      "戊癸合火": "무계합화",
+      "申子辰水局": "신자진수국",
+      "亥卯未木局": "해묘미목국",
+      "寅午戌火局": "인오술화국",
+      "巳酉丑金局": "사유축금국"
+    }
+  },
+  "signature": {
+    "sha256": "..."
+  }
+}
+```
+
+---
+
+## 7. 통합 체크리스트
+
+### Phase 1: 정책 파일 확장
+- [ ] relation_policy.json에 `yuanjin` 필드 추가 (6쌍)
+- [ ] relation_policy.json에 `heavenly.combine.transform`, `earth.he6.transform` 필드 추가
+- [ ] localization_ko_v1.json에 12운성/공망/원진/합화 라벨 20+ 추가
+- [ ] lifecycle_stages.json 검증 (10간 × 12단계 매핑 완전성)
+
+### Phase 2: 엔진 구현
+- [ ] TwelveStageCalculator 구현 (lifecycle_stages.json 로드)
+- [ ] VoidCalculator 구현 (60갑자 → 공망 테이블)
+- [ ] YuanjinDetector 구현 (6쌍 검사)
+- [ ] CombinationElementTransformer 구현 (천간 5쌍 + 지지 삼합/육합)
+
+### Phase 3: AnalysisEngine 통합
+- [ ] engine.py에 4개 엔진 임포트
+- [ ] `analysis.life_stage` 필드 생성 (TwelveStageCalculator 호출)
+- [ ] `analysis.void` 필드 생성 (VoidCalculator 호출)
+- [ ] `analysis.relations.earth.yuanjin` 필드 생성 (YuanjinDetector 호출)
+- [ ] `analysis.wuxing.adjusted.percent` 보정 (CombinationElementTransformer.boost_elements 반영)
+
+### Phase 4: 테스트
+- [ ] test_twelve_stage_calculator.py (4 케이스)
+- [ ] test_void_calculator.py (4 케이스)
+- [ ] test_yuanjin_detector.py (4 케이스)
+- [ ] test_combination_element_transformer.py (4 케이스)
+- [ ] 통합 테스트: AnalysisEngine → 4개 엔진 결과 검증
+
+### Phase 5: KoreanLabelEnricher 통합
+- [ ] 12운성 라벨 보강 (`life_stage.by_pillar.*_ko`)
+- [ ] 공망 라벨 보강 (`void.kong_wang_ko`)
+- [ ] 원진 라벨 보강 (필요 시)
+- [ ] 합화 라벨 보강 (필요 시)
+
+---
+
+**Version:** v1.0 (2025-10-07 KST)
+**Maintainer:** Core Architects (Policy/Engine/Data)

--- a/docs/policy-prompts/30_llm/llm_guard_v1_prompt.md
+++ b/docs/policy-prompts/30_llm/llm_guard_v1_prompt.md
@@ -1,0 +1,340 @@
+# 🛡️ 실행 프롬프트 — LLM Guard v1 (Pre/Post) 스펙 v1.0
+
+**ROLE**
+너는 KO-first **안전·정합성 정책 엔지니어**다. **설명 금지**, **결정적 사양만** 출력한다.
+
+**GOAL**
+사주앱의 LLM 사용 구간에 대해 **Pre-Gen / Post-Gen** 2단계 **LLM Guard v1**의 **정책·스키마·패치 언어·테스트 명세**를 단일 문서로 산출한다.
+출력물은 바로 코드화 가능한 **JSON Schema + 규칙표 + 케이스**로 구성한다.
+
+---
+
+## CONTEXT (고정 사실)
+- LLM은 **설명/요약/코칭**만 수행한다.
+- **정책 기반 산출물(간지/수치/버킷/격국/용신/운세 기둥)**은 엔진이 결정하며, LLM은 수정 금지.
+- 입력 컨텍스트는 `/api/v1/report/saju` 응답(JSON) 중 **허용 경로(facts_paths)**에 한해 노출된다.
+- 응답은 RFC-8785 **canonical JSON** 기준으로 `signatures.sha256` 서명 필드를 포함한다.
+
+---
+
+## OUTPUT ORDER (반드시 준수)
+1) **가드 아키텍처 요약**(Pre-Gen / Post-Gen 단계 정의)
+2) **정책 규칙표**(R1~R6) + 위반 예·처리 액션
+3) **패치 언어(PL1)** 정의( op/start/end/text )
+4) **JSON Schema 4종**: `GuardPolicy`, `PreGuard{Input,Output}`, `PostGuard{Input,Output}`
+5) **이슈 코드 테이블**(CODE/심각도/설명/자동패치 가능 여부)
+6) **예시 3건**(위반→패치 결과)
+7) **단위/통합 테스트 명세**
+8) **수용 기준(AC)**
+
+---
+
+## 1) 가드 아키텍처 요약
+
+- **Pre-Gen**: 사용자 입력과 컨텍스트를 검사하여 **금지 의도/민감 범주**를 차단하고, **사실 경로 화이트리스트(facts_paths)**만 포함하는 **프롬프트 템플릿**을 생성한다.
+  - 실패 시: `mode="safe_notice"`로 전환(카드만 제공, 텍스트 최소화).
+
+- **Post-Gen**: 모델 산출 `llm_text`(및 선택적으로 `cards[]`)를 **정합성/안전성 검사** 후 **자동 패치**하거나 차단.
+  - 우선순위: Grounding→Consistency→Scope→Privacy→Tone.
+  - 결과: `decision ∈ {allow, patched, block}`.
+
+---
+
+## 2) 정책 규칙(R1~R6)
+
+| ID | 규칙명 | 설명 | 위반 예 | 기본 액션 |
+|---|---|---|---|---|
+| **R1** | Grounding(사실연동) | 숫자·간지·날짜·퍼센트는 **허용 경로**의 값만 사용 | "10/12에 계약하세요" (컨텍스트에 없음) | `replace → generic_phrase` |
+| **R2** | Consistency(정합성) | 용신/강약/버킷/간지 등은 **엔진 값과 일치**해야 함 | "신강"이라면서 버킷은 `weak` | `delete segment` |
+| **R3** | Scope(민감주제) | 의료·법률·투자 **구체 행위** 금지(일반 습관 조언만) | "AETF 30% 매수" | `block_or_safe_notice` |
+| **R4** | Tone(어조) | 단정·공포·숙명론 금지 → 코칭형으로 완화 | "반드시 실패합니다" | `replace → hedge_phrase` |
+| **R5** | Privacy(개인정보) | 이름/성별/생년월일 외 PII 재노출 금지 | 전화/주소/이메일 언급 | `redact` |
+| **R6** | Grounded Date Window | 월운 기간 외 **임의 날짜** 금지(예: `term_window` 밖) | 기간 밖 날짜 추천 | `replace → within_window_hint` |
+
+**허용 경로 예(facts_paths subset)**
+`analysis.wuxing.raw.percent.*`, `analysis.wuxing.status_tag.*`, `analysis.strength.*`,
+`analysis.yongshin.*`, `analysis.luck.decades.*`, `analysis.luck.years.*`, `analysis.luck.months.*`,
+`pillars.*`, `localization.ko`
+
+**금지 패턴(예시, ko/en)**
+- 의료: 치료/복용/처방/용량, "treat/cure/dose/prescribe"
+- 법률: 고소/소송/계약 무효, "sue/illegal/void contract"
+- 투자: 수익률 보장/매수·매도 지시, "buy/sell/guarantee return"
+- 숙명론: "반드시/결정되어 있다/피할 수 없다"
+
+---
+
+## 3) 패치 언어(PL1)
+
+```json
+{
+  "op": "replace | delete | redact",
+  "start": 42,
+  "end": 57,
+  "text": "일반적인 정리·기록 습관을 우선하세요."  // op=replace 일 때만
+}
+```
+
+- 인덱스는 UTF-16 code unit 기준.
+- 여러 패치는 앞→뒤 순서로 적용.
+- `redact`는 동일 길이 별표(*) 대체를 권장.
+
+---
+
+## 4) JSON Schema
+
+### 4.1 GuardPolicy (정책 설정)
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://example.com/schemas/guard_policy_v1.schema.json",
+  "type":"object",
+  "required":["facts_paths","blocked_topics","tone","privacy","grounding","signatures"],
+  "properties":{
+    "facts_paths":{"type":"array","items":{"type":"string"}},
+    "grounding":{
+      "type":"object",
+      "properties":{
+        "allow_ganzhi": {"type":"boolean","default": true},
+        "allow_percent": {"type":"boolean","default": true},
+        "allow_dates_iso8601": {"type":"boolean","default": true},
+        "date_window_sec": {"type":"integer","minimum":0,"default": 0}
+      }
+    },
+    "blocked_topics":{
+      "type":"object",
+      "properties":{
+        "medical":{"type":"array","items":{"type":"string"}},
+        "legal":{"type":"array","items":{"type":"string"}},
+        "finance":{"type":"array","items":{"type":"string"}}
+      }
+    },
+    "tone":{
+      "type":"object",
+      "properties":{
+        "banned_phrases":{"type":"array","items":{"type":"string"}},
+        "hedge_phrases":{"type":"array","items":{"type":"string"}}
+      }
+    },
+    "privacy":{
+      "type":"object",
+      "properties":{
+        "allow_name":{"type":"boolean","default":true},
+        "allow_gender":{"type":"boolean","default":true},
+        "allow_birth":{"type":"boolean","default":true},
+        "ban_patterns":{"type":"array","items":{"type":"string"}}
+      }
+    },
+    "consistency":{
+      "type":"object",
+      "properties":{
+        "enforce_yongshin":{"type":"boolean","default":true},
+        "enforce_strength_bucket":{"type":"boolean","default":true}
+      }
+    },
+    "signatures":{"type":"object","properties":{"sha256":{"type":"string","pattern":"^[A-Fa-f0-9]{64}$"}}}
+  },
+  "additionalProperties": false
+}
+```
+
+### 4.2 PreGuard
+
+#### Input
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://example.com/schemas/preguard_input_v1.schema.json",
+  "type":"object",
+  "required":["message","intent","depth","context","policy"],
+  "properties":{
+    "message":{"type":"string","minLength":1,"maxLength":2000},
+    "intent":{"type":"string","enum":["today","month","year","money","work","study","move","love","match","general"]},
+    "depth":{"type":"string","enum":["auto","light","deep"]},
+    "context":{"type":"object"},
+    "policy":{"$ref":"https://example.com/schemas/guard_policy_v1.schema.json"}
+  }
+}
+```
+
+#### Output
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://example.com/schemas/preguard_output_v1.schema.json",
+  "type":"object",
+  "required":["mode","template","facts_paths","issues","signatures"],
+  "properties":{
+    "mode":{"type":"string","enum":["normal","safe_notice","blocked"]},
+    "template":{"type":"string"},
+    "facts_paths":{"type":"array","items":{"type":"string"}},
+    "issues":{"type":"array","items":{"$ref":"https://example.com/schemas/guard_issue_v1.schema.json"}},
+    "signatures":{"type":"object","properties":{"sha256":{"type":"string","pattern":"^[A-Fa-f0-9]{64}$"}}}
+  }
+}
+```
+
+### 4.3 PostGuard
+
+#### Input
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://example.com/schemas/postguard_input_v1.schema.json",
+  "type":"object",
+  "required":["llm_text","context","policy"],
+  "properties":{
+    "llm_text":{"type":"string","minLength":1},
+    "cards":{"type":"array","items":{"type":"object"}},
+    "context":{"type":"object"},
+    "policy":{"$ref":"https://example.com/schemas/guard_policy_v1.schema.json"}
+  }
+}
+```
+
+#### Output
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://example.com/schemas/postguard_output_v1.schema.json",
+  "type":"object",
+  "required":["decision","issues","patches","text_final","signatures"],
+  "properties":{
+    "decision":{"type":"string","enum":["allow","patched","block"]},
+    "issues":{"type":"array","items":{"$ref":"https://example.com/schemas/guard_issue_v1.schema.json"}},
+    "patches":{"type":"array","items":{"$ref":"https://example.com/schemas/guard_patch_v1.schema.json"}},
+    "text_final":{"type":"string"},
+    "signatures":{"type":"object","properties":{"sha256":{"type":"string","pattern":"^[A-Fa-f0-9]{64}$"}}}
+  }
+}
+```
+
+### 4.4 Issue/Patch Schemas
+
+#### GuardIssue
+```json
+{
+  "$id":"https://example.com/schemas/guard_issue_v1.schema.json",
+  "type":"object",
+  "required":["code","severity","message"],
+  "properties":{
+    "code":{"type":"string"},
+    "severity":{"type":"string","enum":["low","medium","high","critical"]},
+    "message":{"type":"string"},
+    "path":{"type":["string","null"]},
+    "span":{"type":["array","null"],"items":{"type":"integer"}}
+  }
+}
+```
+
+#### GuardPatch
+```json
+{
+  "$id":"https://example.com/schemas/guard_patch_v1.schema.json",
+  "type":"object",
+  "required":["op","start","end"],
+  "properties":{
+    "op":{"type":"string","enum":["replace","delete","redact"]},
+    "start":{"type":"integer","minimum":0},
+    "end":{"type":"integer","minimum":0},
+    "text":{"type":["string","null"]}
+  }
+}
+```
+
+---
+
+## 5) 이슈 코드 테이블
+
+| CODE | 심각도 | 설명 | 자동패치 |
+|---|---|---|---|
+| `GROUND_UNVERIFIED` | high | 컨텍스트에 없는 수치/날짜/간지 | ✔ replace/delete |
+| `CONSIST_MISMATCH` | high | 엔진 값과 상충(용신/강약/간지 등) | ✔ delete |
+| `SCOPE_RESTRICTED` | critical | 의료/법률/투자 구체 행위 | ▲ safe_notice / block |
+| `TONE_FATALISM` | medium | 단정/숙명론 어휘 사용 | ✔ replace(hedge) |
+| `PRIVACY_LEAK` | high | PII 노출(이름·성별·생년 제외) | ✔ redact |
+| `DATE_OUT_OF_WINDOW` | high | term_window 밖 날짜 언급 | ✔ replace(within_window_hint) |
+| `FORMAT_INVALID` | low | 잘못된 포맷(YYYY-MM 등) | ✔ replace |
+
+---
+
+## 6) 예시 (위반 → 패치)
+
+### 6.1 Grounding 위반
+**입력 llm_text**: "10/12 계약이 반드시 유리합니다."
+**컨텍스트**: `analysis.luck.months["2025-10"].term_window = 10/08~11/07` (날짜 값 없음, 창만 있음)
+
+**결과**:
+```json
+{
+  "decision":"patched",
+  "issues":[{"code":"GROUND_UNVERIFIED","severity":"high","message":"임의 날짜"}],
+  "patches":[
+    {"op":"replace","start":0,"end":14,"text":"기간 내 중요한 문서는 검토 후 진행이 유리합니다."},
+    {"op":"replace","start":14,"end":22,"text":"지나치게 단정하지 말고"}
+  ],
+  "text_final":"기간 내 중요한 문서는 검토 후 진행이 유리합니다. 지나치게 단정하지 말고 상황에 맞춰 결정하세요.",
+  "signatures":{"sha256":"<PLACEHOLDER>"}
+}
+```
+
+### 6.2 Scope 위반(투자)
+**입력**: "이번 달 AETF 30% 매수가 최선입니다."
+
+**결과**:
+```json
+{
+  "decision":"block",
+  "issues":[{"code":"SCOPE_RESTRICTED","severity":"critical","message":"투자 구체 행위"}],
+  "patches":[],
+  "text_final":"안전: 투자·의료·법률의 구체 행위는 제공하지 않으며, 기록·예산·상담 등 일반적 습관을 권장합니다.",
+  "signatures":{"sha256":"<PLACEHOLDER>"}
+}
+```
+
+### 6.3 Consistency 위반(강약 상충)
+**컨텍스트**: `analysis.strength.bucket="weak"`
+**입력**: "당신은 신강이라 강하게 밀어붙이세요."
+
+**결과**:
+```json
+{
+  "decision":"patched",
+  "issues":[{"code":"CONSIST_MISMATCH","severity":"high","message":"강약 상충"}],
+  "patches":[{"op":"replace","start":4,"end":13,"text":"약한 편이므로 기본 루틴을 지키며"}],
+  "text_final":"당신은 약한 편이므로 기본 루틴을 지키며 점진적으로 진행하세요.",
+  "signatures":{"sha256":"<PLACEHOLDER>"}
+}
+```
+
+---
+
+## 7) 테스트 명세
+
+### 단위(Pre-Gen)
+- 의료/법률/투자 키워드 탐지 → `mode="safe_notice"`
+- `facts_paths` 화이트리스트 외 경로 제거 확인
+
+### 단위(Post-Gen)
+- **Grounding**: 임의 수치/간지/날짜 탐지·치환
+- **Consistency**: 용신·강약·간지 상충 탐지·삭제
+- **Privacy**: 이메일/전화/주소 마스킹
+- **Tone**: 금지 어휘 → hedge 치환
+- **Date Window**: `term_window` 밖 날짜 → 범용 문구 치환
+
+### 통합
+- `/chat/send(deep)` 성공 플로우에서 `reserve→finalize`와 Guard 패치 결과의 서명 필드 생성 확인
+- LLM 산출이 차단될 경우 카드만 응답 경로로 전환
+
+---
+
+## 8) 수용 기준(AC)
+- Pre/Post 두 단계 모두 스키마·규칙·패치 언어·이슈코드가 완비되어야 함
+- 예시 3건이 정책→패치→최종 텍스트 흐름을 보여야 함
+- JSON Schema는 draft-2020-12 지정 및 필수 키 포함
+- Post-Gen 결과는 항상 `signatures.sha256` 필드를 포함
+
+---
+
+## NOW OUTPUT
+위 형식을 그대로 따라 LLM Guard v1 사양 문서를 생성하라. 불필요한 설명·주석 없이 정책·스키마·표·예시·테스트만 출력.

--- a/docs/policy-prompts/30_llm/llm_templates_5pack_prompt.md
+++ b/docs/policy-prompts/30_llm/llm_templates_5pack_prompt.md
@@ -1,0 +1,267 @@
+# 🧩 실행 프롬프트 — LLM 템플릿 5종(오행/용신/강약/대운/연·월운) v1.0
+
+**ROLE**
+너는 **KO-first 템플릿 엔지니어**다. **설명 금지**, **결정적 산출물만** 출력한다.
+
+**GOAL**
+아래 5개 주제의 **문장 템플릿 팩**을 **단일 JSON**으로 산출하라.
+각 주제마다 **Light(≤300t)** / **Deep(≤900t)** / **PDF(≤1300t)** 3등급 버전과, 필수 **facts_keys**(필드 경로) 목록을 포함한다.
+템플릿은 **사실 슬롯**만 사용하고, 숫자/간지/연·월 등 **추가 생성 금지**(컨텍스트 값만 참조).
+
+**TEMPLATES (5)**
+1) `wuxing_summary` — 오행 분포 요약 및 균형 코칭
+2) `yongshin_explain` — 용신 유형/오행/근거 설명
+3) `strength_explain` — 신강/신약 점수·버킷 해석
+4) `decades_commentary` — 대운(10년 단위) 흐름 요약 코멘트
+5) `annual_monthly_commentary` — 연운·월운 핵심 포인트 + 7일/1기 티저
+
+---
+
+## CONTEXT MAP (팩트 경로; /report/saju 응답 기준)
+- 일반: `pillars.*`, `analysis.*`, `localization.ko`
+- 오행: `analysis.wuxing.raw.percent.{木,火,土,金,水}`, `analysis.wuxing.status_tag`, `analysis.day_master.element`(= `pillars.day.stem` 파생 KO)
+- 용신: `analysis.yongshin.{type,elements[],rationale.evidence[]}`, `analysis.strength.bucket`
+- 강약: `analysis.strength.{score,bucket,factors[]}`
+- 대운: `analysis.luck.decades.{start_age,direction,pillars[].{age,pillar,ten_god,stage}}`
+- 연운: `analysis.luck.years.{YYYY}.{pillar,ten_god,stage?}`
+- 월운: `analysis.luck.months.{YYYY-MM}.{pillar,ten_god,stage?,term_window.{start,end}}`
+
+> **금지**: 템플릿 본문에서 위 경로 외 값(추가 숫자·날짜·간지)을 **창작 금지**.
+
+---
+
+## SAFETY & GUARD (반드시 준수)
+- **Grounding**: 숫자·간지·연·월은 **facts_keys**에 한함. 없으면 출력하지 말고 `{{MISSING(...)}}` 사용.
+- **Scope**: 의료/법률/투자 **구체 조언 금지**. 일상/습관/커뮤니케이션 중심 코칭.
+- **Tone**: 단정/공포/숙명론 금지. **코칭형**(선택지/대안 제시).
+- **Privacy**: 사용자 신상 재노출 금지(이름/생년 제외).
+- **Consistency**: 용신/강약/버킷/날짜가 컨텍스트와 상충 시, 문장 **생략**.
+- **Fallback**: 필수 슬롯 누락 시 **안전 답변**: "확인된 정보 범위에서만 안내합니다." 한 줄 + 가능한 문단만 출력.
+
+---
+
+## OUTPUT FORMAT (단일 JSON; draft-like)
+- **반드시 아래 스키마로만 출력**: 불필요한 설명/주석 금지.
+
+```json
+{
+  "pack_id": "llm_templates_5pack_v1",
+  "lang": "ko-KR",
+  "templates": {
+    "<topic>": {
+      "facts_keys": ["<dot.path>", "..."],
+      "light": "<TEMPLATE_TEXT>",
+      "deep": "<TEMPLATE_TEXT>",
+      "pdf": "<TEMPLATE_TEXT>"
+    }
+  }
+}
+```
+
+### Placeholder 규칙
+- **변수**: `{{analysis.wuxing.raw.percent.木}}`, `{{analysis.yongshin.elements[0]}}`
+- **조건(최소한)**: `{{? analysis.wuxing.status_tag.金 == 'over' }} ... {{/}}`
+- **선택 출력**: `{{opt analysis.yongshin.elements}}수(⽔){{/opt}}` (배열 있으면 첫 요소만 명시)
+- **누락 경고**: `{{MISSING('analysis.luck.months')}}` (Guard가 후처리로 제거/대체)
+- **템플릿 엔진 가정**: `{{...}}` 값 치환, `{{? cond}}...{{/}}` 조건, `{{opt key}}...{{/opt}}` 존재 시만 출력. 반복문/정렬 없음.
+
+---
+
+## STYLE GUIDE
+- 문단 1~3개. 제목 한 줄(선택) + 핵심 요약 1문장 + 근거 2~3개 + 실행 팁 1~2개.
+- 고유명/한자 표기는 한글 우선, 필요 시 병기: 예) "금(金)".
+- 날짜/기간 언급은 컨텍스트 값만(예: `{{term_window.start}}`), 상대표현(이번/다음)은 금지.
+- 긍정/중립 어투: "권장/피하기보단/정리·기록/체크리스트".
+- 불가: 점괘식 확정, 재무 추정, 의학적 처방, 법률 판단.
+
+---
+
+## TEMPLATE SPEC (5 Topics)
+
+### 1) wuxing_summary
+**facts_keys (예시)**
+- `analysis.wuxing.raw.percent.{木,火,土,金,水}`
+- `analysis.wuxing.status_tag`
+- `analysis.day_master.element`
+
+**light**
+```
+요약: 현재 오행 분포에서 {{analysis.wuxing.status_tag.top?}}값이 두드러집니다.
+{{? analysis.wuxing.status_tag.金 == 'over'}}금(金)이 강조되어 규칙·정리·문서 기반 정돈이 유리합니다.{{/}}
+{{? analysis.wuxing.status_tag.木 == 'under'}}목(木)이 약하므로 계획 대비 실행 체크리스트를 간단히 운용하세요.{{/}}
+실천 팁: 오늘 할 일 3가지를 **기록→정리→확인** 순으로 마무리해 보세요.
+```
+
+**deep**
+```
+오행 분포 정리:
+- 목(木) {{analysis.wuxing.raw.percent.木}}%, 화(火) {{analysis.wuxing.raw.percent.火}}%, 토(土) {{analysis.wuxing.raw.percent.土}}%, 금(金) {{analysis.wuxing.raw.percent.金}}%, 수(⽔) {{analysis.wuxing.raw.percent.水}}%.
+핵심: {{analysis.day_master.element}} 기준으로 {{analysis.wuxing.status_tag.focus}}가 흐름을 좌우합니다.
+근거:
+1) {{? analysis.wuxing.status_tag.金 == 'over'}}정리/규칙/마감 준수에 강점.{{/}}
+2) {{? analysis.wuxing.status_tag.木 == 'under'}}새 계획 남발보다 기존 계획의 실행률 관리가 우선.{{/}}
+실천: 주 2회 **정리 타임**을 캘린더에 고정하고, 완료 체크를 남겨두세요.
+```
+
+**pdf**
+```
+[오행 분포 리포트]
+분포: 목 {{analysis.wuxing.raw.percent.木}}% · 화 {{analysis.wuxing.raw.percent.火}}% · 토 {{analysis.wuxing.raw.percent.土}}% · 금 {{analysis.wuxing.raw.percent.金}}% · 수 {{analysis.wuxing.raw.percent.水}}%
+요약: {{analysis.day_master.element}} 기준, {{analysis.wuxing.status_tag.summary}}.
+해석 포인트:
+- 과다: {{? analysis.wuxing.status_tag.金 == 'over'}}금(金) 중심 — 규칙, 검토, 문서화 강화.{{/}}
+- 부족: {{? analysis.wuxing.status_tag.木 == 'under'}}목(木) 보완 — 실행 체크리스트·정기 점검.{{/}}
+권장 루틴: ①정리 ②우선순위 선정 ③마감 확인.
+```
+
+---
+
+### 2) yongshin_explain
+**facts_keys**
+- `analysis.yongshin.{type,elements[],rationale.evidence[]}`
+- `analysis.strength.bucket`
+
+**light**
+```
+용신: {{analysis.yongshin.elements[0]}} 중심(유형: {{analysis.yongshin.type}}).
+이유: {{analysis.yongshin.rationale.evidence[0]}} · {{analysis.yongshin.rationale.evidence[1]?}}
+활용 팁: 관련 성질을 **습관/환경**으로 보완해 주세요.
+```
+
+**deep**
+```
+용신 해설(유형: {{analysis.yongshin.type}}):
+핵심 오행: {{analysis.yongshin.elements}}.
+근거:
+- {{analysis.yongshin.rationale.evidence[0]}}
+- {{analysis.yongshin.rationale.evidence[1]?}}
+신강/신약: {{analysis.strength.bucket}} 경향에 따라 실천 강도를 조절하세요.
+실천: 주간 루틴에 {{analysis.yongshin.elements[0]}} 성질을 반영한 **행동 2가지**를 고정합니다.
+```
+
+**pdf**
+```
+[용신 리포트]
+유형: {{analysis.yongshin.type}} / 핵심 오행: {{analysis.yongshin.elements}}
+판단 근거:
+1) {{analysis.yongshin.rationale.evidence[0]}}
+2) {{analysis.yongshin.rationale.evidence[1]?}}
+코칭:
+- 환경: 용신 성질을 지지하는 업무/공간 세팅
+- 루틴: 주 {{analysis.yongshin.elements[0]}} 성질에 맞춘 체크리스트 고정
+```
+
+---
+
+### 3) strength_explain
+**facts_keys**
+- `analysis.strength.{score,bucket,factors[]}`
+
+**light**
+```
+신강/신약 요약: {{analysis.strength.bucket}} (점수 {{analysis.strength.score}}).
+근거: {{analysis.strength.factors[0]}} · {{analysis.strength.factors[1]?}}
+권장: **루틴 고정 + 기록**으로 과소/과다를 완화하세요.
+```
+
+**deep**
+```
+신강/신약 해석 — 점수 {{analysis.strength.score}}, 버킷 {{analysis.strength.bucket}}.
+영향 요인:
+- {{analysis.strength.factors[0]}}
+- {{analysis.strength.factors[1]?}}
+코칭:
+- 집중: 하루 초반 고정 작업 블록 확보
+- 보완: 주간 검토(15분)로 과부하/지연을 체크
+```
+
+**pdf**
+```
+[신강/신약 리포트]
+지표: {{analysis.strength.score}}점 / 분류: {{analysis.strength.bucket}}
+주요 요인: {{analysis.strength.factors}}
+실행 전략:
+- 스케줄: 우선순위 3개만 확정, 나머지 유예
+- 체크: 주 1회 성과 로그 기록
+```
+
+---
+
+### 4) decades_commentary
+**facts_keys**
+- `analysis.luck.decades.{start_age,direction,pillars[].{age,pillar,ten_god,stage}}`
+- `analysis.yongshin.elements[]` (선택)
+
+**light**
+```
+대운 시작: {{analysis.luck.decades.start_age}}세 ({{analysis.luck.decades.direction}}).
+현재/다가오는 운의 키워드: {{analysis.luck.decades.pillars[0].ten_god}} 중심.
+팁: **기록·정리·관계 조율** 같은 기본기를 유지하세요.
+```
+
+**deep**
+```
+대운 흐름(시작 {{analysis.luck.decades.start_age}}세, {{analysis.luck.decades.direction}}):
+- 구간 A: {{analysis.luck.decades.pillars[0].age}}세 — {{analysis.luck.decades.pillars[0].ten_god}}/{{analysis.luck.decades.pillars[0].stage}}
+- 구간 B: {{analysis.luck.decades.pillars[1].age}}세 — {{analysis.luck.decades.pillars[1].ten_god}}/{{analysis.luck.decades.pillars[1].stage}}
+핵심: 변화 구간에는 **기록·정리·우선순위 재배치**가 유효합니다.
+```
+
+**pdf**
+```
+[대운 타임라인]
+방향: {{analysis.luck.decades.direction}} / 시작연령: {{analysis.luck.decades.start_age}}세
+구간 요약:
+- {{analysis.luck.decades.pillars[0].age}}세: {{analysis.luck.decades.pillars[0].pillar}} ({{analysis.luck.decades.pillars[0].ten_god}}/{{analysis.luck.decades.pillars[0].stage}})
+- {{analysis.luck.decades.pillars[1].age}}세: {{analysis.luck.decades.pillars[1].pillar}} ({{analysis.luck.decades.pillars[1].ten_god}}/{{analysis.luck.decades.pillars[1].stage}})
+가이드: 큰 결정을 앞두고 **정보 수집→정리→검토** 순서를 지키세요.
+```
+
+---
+
+### 5) annual_monthly_commentary
+**facts_keys**
+- 연: `analysis.luck.years.{YYYY}.{pillar,ten_god,stage?}`
+- 월: `analysis.luck.months.{YYYY-MM}.{pillar,ten_god,stage?,term_window.{start,end}}`
+
+**light**
+```
+이번 기간 포인트: 연 {{analysis.luck.years.Y.pillar}} / 월 {{analysis.luck.months.YM.pillar}}.
+핵심 십성: {{analysis.luck.months.YM.ten_god}} 중심.
+팁: 기간( {{analysis.luck.months.YM.term_window.start}} ~ {{analysis.luck.months.YM.term_window.end}} ) 동안 **정리·기록**에 시간을 고정하세요.
+```
+
+**deep**
+```
+연·월 포인트:
+- 연: {{analysis.luck.years.Y.pillar}} ({{analysis.luck.years.Y.ten_god}}/{{analysis.luck.years.Y.stage?}})
+- 월: {{analysis.luck.months.YM.pillar}} ({{analysis.luck.months.YM.ten_god}}/{{analysis.luck.months.YM.stage?}})
+기간: {{analysis.luck.months.YM.term_window.start}} ~ {{analysis.luck.months.YM.term_window.end}}
+코칭: 기간 초반 **계획 정비**, 중반 **실행 체크**, 후반 **정리/기록** 순으로 운영하세요.
+```
+
+**pdf**
+```
+[연·월운 리포트]
+연간: {{analysis.luck.years.Y.pillar}} / 십성 {{analysis.luck.years.Y.ten_god}} / 단계 {{analysis.luck.years.Y.stage?}}
+월간: {{analysis.luck.months.YM.pillar}} / 십성 {{analysis.luck.months.YM.ten_god}} / 단계 {{analysis.luck.months.YM.stage?}}
+기간 창: {{analysis.luck.months.YM.term_window.start}} ~ {{analysis.luck.months.YM.term_window.end}}
+운영 제안:
+- 계획: 우선순위 3개 확정
+- 실행: 주 2회 진행률 점검
+- 정리: 기간 종료 전 마감 체크
+```
+
+---
+
+## ACCEPTANCE CRITERIA
+- 출력은 단일 JSON이며, `pack_id`/`lang`/`templates` 구조를 따른다.
+- 각 토픽에 `facts_keys`와 `light`/`deep`/`pdf` 3개 본문이 존재한다.
+- 본문은 KO-first, 사실 슬롯만 사용하며 금지사항(의료/법률/투자 구체조언, 임의 수치·날짜 생성)을 위반하지 않는다.
+- 누락 값은 `{{MISSING(...)}}` 또는 조건 블록 생략으로 대응한다.
+- 길이 한도: Light ≤300t, Deep ≤900t, PDF ≤1300t에 맞춰 간결하게 작성한다.
+
+---
+
+## NOW OUTPUT
+위 스펙에 맞는 템플릿 팩 JSON을 그대로 출력하라. 불필요한 설명이나 주석은 금지.

--- a/docs/policy-prompts/30_llm/model_routing_policy_prompt.md
+++ b/docs/policy-prompts/30_llm/model_routing_policy_prompt.md
@@ -1,0 +1,211 @@
+# 🔀 실행 프롬프트 — 모델 라우팅 정책(Model Routing Policy) v1.0
+
+**ROLE**
+너는 KO-first **플랫폼 라우팅 정책 엔지니어**다. **설명 금지**, **결정적 사양만** 출력한다.
+
+**GOAL**
+사주앱의 LLM 호출을 위한 **모델 카탈로그/라우팅 규칙/폴백/타임아웃/재시도/비용 가중치/관측 지표**를 한 문서로 산출한다.
+출력물은 **표 + JSON 설정(config) + 의사코드 + 테스트 명세**로 구성되며, 바로 코드화 가능해야 한다.
+
+**CONTEXT (고정)**
+- 채팅 오케스트레이터 `/api/v1/chat/send`의 Depth: **Light(≤300t)** / **Deep(≤900t)** / *(옵션)* Report-style(채팅 내 소규모 리포트).
+- 텍스트 생성은 **템플릿→LLM-polish**, 사실/수치/간지는 **엔진 결과**로만(LLM Guard v1 적용).
+- 언어: `ko-KR` 우선.
+- 네트워크/비용/지연 조건에 따라 **자동 폴백**.
+
+---
+
+## OUTPUT ORDER (반드시 이 순서)
+1) **문서 헤더**(제목/버전/날짜/베이스URL/보안)
+2) **Model Catalog 표** + **models.json(설정 JSON)**
+3) **Routing Matrix 표**(Light/Deep/Report × 1차/2차/Backstop, 타임아웃·재시도·온도 등)
+4) **Selection 의사코드**(입력→라우팅 결정→호출)
+5) **Fallback/Retry 정책**(트리거·쿨다운·승격 금지 조건)
+6) **비용·성능·품질 가중치 정의**(가중치 JSON + 예시 계산)
+7) **안전/가드 연동 규칙**(LLM Guard v1과의 상호작용)
+8) **관측/로그/메트릭 이벤트**(이벤트 키·라벨)
+9) **A/B·Canary 규칙**(버킷·노출·롤백)
+10) **테스트 명세**(단위/통합)
+11) **수용 기준(AC)**
+
+---
+
+## 1) 문서 헤더(샘플 형식)
+- 제목: *Model Routing Policy v1.0*
+- 날짜: 2025-10-07 KST
+- Base URL: `<PLACEHOLDER>`
+- 인증: `Authorization: Bearer <token>`
+
+---
+
+## 2) Model Catalog
+
+### 2.1 표
+| id | provider | tier | ko_quality(1-5) | latency_tier(1-5) | price_weight | ctx_window | max_output_tokens | notes |
+|---|---|---|---:|---:|---:|---:|---:|---|
+| qwen-flash | Alibaba | fast | 4 | 5 | 0.25 | 32k | 512 | 저비용/한글 양호 |
+| deepseek-chat | DeepSeek | fast | 4 | 5 | 0.2 | 32k | 512 | 초저비용/요약 강점 |
+| gemini-2.5-pro | Google | balanced | 5 | 3 | 1.0 | 128k | 1024 | 긴 컨텍스트/서술 안정 |
+| gpt-5 | OpenAI | premium | 5 | 2 | 2.0 | 200k | 1200 | 품질 백스톱 |
+| (optional) local-mini | Local | dev | 2 | 5 | 0.05 | 8k | 256 | 오프라인 디버그용 |
+
+> `price_weight`는 상대 가중치(실가격 아님). 라우팅 비용 함수에 사용.
+
+### 2.2 설정 JSON — `models.json`
+```json
+{
+  "models": [
+    {"id":"qwen-flash","provider":"alibaba","price_weight":0.25,"ctx_window":32768,"max_output_tokens":512,"ko_quality":4,"latency_tier":5},
+    {"id":"deepseek-chat","provider":"deepseek","price_weight":0.2,"ctx_window":32768,"max_output_tokens":512,"ko_quality":4,"latency_tier":5},
+    {"id":"gemini-2.5-pro","provider":"google","price_weight":1.0,"ctx_window":131072,"max_output_tokens":1024,"ko_quality":5,"latency_tier":3},
+    {"id":"gpt-5","provider":"openai","price_weight":2.0,"ctx_window":200000,"max_output_tokens":1200,"ko_quality":5,"latency_tier":2},
+    {"id":"local-mini","provider":"local","price_weight":0.05,"ctx_window":8192,"max_output_tokens":256,"ko_quality":2,"latency_tier":5}
+  ],
+  "defaults": {
+    "light": {"temperature":0.2,"top_p":1.0,"max_output_tokens":280,"timeout_ms":[3000,7000,10000]},
+    "deep":  {"temperature":0.35,"top_p":1.0,"max_output_tokens":900,"timeout_ms":[8000,15000]},
+    "report": {"temperature":0.35,"top_p":1.0,"max_output_tokens":1200,"timeout_ms":[12000]}
+  }
+}
+```
+
+---
+
+## 3) Routing Matrix
+
+| Depth/Type | 1차 | 2차(Fallback) | Backstop | 온도 | 타임아웃(계단) | 재시도 |
+|---|---|---|---|---:|---|---|
+| Light (≤300t) | qwen-flash or deepseek-chat | gemini-2.5-pro | gpt-5 | 0.2 | 3s → 7s → 10s | 네트워크 1회 |
+| Deep (≤900t) | gemini-2.5-pro | gpt-5 | — | 0.35 | 8s → 15s | 네트워크 1회 |
+| Report-style(채팅 내) | gemini-2.5-pro | gpt-5 | — | 0.35 | 12s | 0 |
+
+**보조 규칙**:
+- Light에서 Guard 정합성 실패시 즉시 상위 모델 승격 금지 → 먼저 템플릿 축약 후 동일 모델 1회 재시도.
+- 지역/규정 이슈 발생 시 `local-mini`로 안전 메시지 생성(개발/드릴 전용).
+
+---
+
+## 4) Selection 의사코드
+
+```python
+function select_model(depth, intent, locale, guard_state, budgets):
+  C = load(models.json)
+  if depth == "light":
+     primary = prefer_low_cost(["qwen-flash","deepseek-chat"], budgets)
+     fallback = "gemini-2.5-pro"; backstop = "gpt-5"
+     cfg = C.defaults.light
+  else if depth == "deep":
+     primary = "gemini-2.5-pro"; fallback = "gpt-5"; backstop = null
+     cfg = C.defaults.deep
+  else if depth == "report":
+     primary = "gemini-2.5-pro"; fallback = "gpt-5"; cfg = C.defaults.report
+
+  // ko 품질 가중
+  if locale == "ko-KR" and ko_quality(primary) < 4:
+     primary = "gemini-2.5-pro"
+
+  // Guard 프리체크 실패 시 안전 템플릿으로 다운스케일
+  if guard_state == "safe_notice":
+     return ("qwen-flash", cfg with max_output_tokens=min(220, cfg.max_output_tokens))
+
+  return (primary, cfg, fallback, backstop)
+```
+
+---
+
+## 5) Fallback/Retry 정책
+
+- **재시도 트리거**: 408/429/5xx/네트워크 오류/모델 타임아웃.
+- **승격 금지 조건**: Post-Guard 정합성 위반(Consistency/Grounding) → 템플릿 축약 후 동일 모델 재시도 1회.
+- **쿨다운**: 동일 모델 동일 입력 해시 30초 내 재시도 금지(멱등 방지).
+- **백스톱 활성화**: Fallback 실패 + 중요도 high(Deep/Report)일 때만.
+- **중단 기준**: 2회 실패 시 안전 응답(카드만 + 안내 문구).
+
+---
+
+## 6) 비용·성능·품질 가중치
+
+### 함수
+```
+score = w_price * (1/price_weight) + w_latency * latency_tier + w_ko * ko_quality
+```
+
+- **기본**: `w_price=0.5`, `w_latency=0.2`, `w_ko=0.3`
+- **예산 압박 모드**(월 누적 비용 초과): `w_price=0.7`, `w_latency=0.15`, `w_ko=0.15`
+- **긴 문맥 모드**(컨텍스트 길이 ≥32k): force `gemini-2.5-pro` or `gpt-5`
+
+### 설정 JSON — `routing_weights.json`
+```json
+{
+  "weights": {
+    "default": {"w_price":0.5,"w_latency":0.2,"w_ko":0.3},
+    "budget": {"w_price":0.7,"w_latency":0.15,"w_ko":0.15}
+  },
+  "thresholds": {
+    "budget_mode_monthly_cost_usd": 1000,
+    "long_context_tokens": 32000
+  }
+}
+```
+
+---
+
+## 7) 안전/가드 연동
+
+- **Pre-Guard**: 금지 의도/민감 주제 감지 시 `mode="safe_notice"` → Light/저온도/짧은 토큰으로 강등.
+- **Post-Guard**:
+  - `GROUND_UNVERIFIED`/`CONSIST_MISMATCH` → 승격 금지, 템플릿 축약 후 동일 모델 재시도.
+  - `SCOPE_RESTRICTED` → 차단 및 카드만.
+- 모든 최종 텍스트는 `signatures.sha256` 포함.
+
+---
+
+## 8) 관측/로그/메트릭
+
+### 이벤트 키:
+- `route.decide(depth, model, weights, reason)`
+- `route.fallback(from, to, cause)`
+- `llm.request(model, input_tokens, max_output, timeout_ms)`
+- `llm.response(latency_ms, output_tokens, finish_reason)`
+- `guard.post.result(decision, issues[])`
+- 비용 집계: `billing.sample(model, cost_estimate)`
+
+### 지표:
+- 성공률, p50/p95 지연, 평균 비용/호출, Guard 패치율, 승격률
+
+---
+
+## 9) A/B·Canary
+
+- **버킷**: A: `qwen-flash` 우선, B: `deepseek-chat` 우선 (Light 전용), 50/50
+- **기간**: 7일 롤링, KPI: 비용/호출, p95 지연, Guard 패치율
+- **Canary**: 신규 모델 도입 시 5% → 25% → 100% 단계적 확대, 이상 시 즉시 롤백
+
+---
+
+## 10) 테스트 명세
+
+### 단위
+- `ko-KR` + Light → qwen/deepseek 중 하나 반환
+- 긴 문맥(>32k) → gemini/gpt-5 강제 선택
+- budget mode 활성화 시 가격 가중 반영 확인
+- Guard `safe_notice` → Light/저온도 강등
+
+### 통합
+- Light 1차 타임아웃 → Fallback으로 성공
+- Post-Guard Consistency 위반 → 동일 모델 템플릿 축약 재시도, 승격 금지 확인
+- Deep 백스톱 gpt-5 경로 1건
+
+---
+
+## 11) 수용 기준(AC)
+- Model Catalog 표 + `models.json`이 포함되어야 함
+- Routing Matrix가 Light/Deep/Report 각각 1차/2차/Backstop를 명시
+- Selection 의사코드와 Fallback/Retry 정책이 구체적이어야 함
+- 비용·성능·품질 가중치와 설정 JSON이 포함되어야 함
+- Guard 연동/관측/A-B/테스트 명세가 포함되어야 함
+
+---
+
+## NOW OUTPUT
+위 형식을 그대로 따라 모델 라우팅 정책 문서를 생성하라. 불필요한 설명·주석 없이 표/JSON/의사코드/정책/테스트만 출력.

--- a/docs/policy-prompts/40_tokens_entitlements_ads/tokens_entitlements_ssv_prompt.md
+++ b/docs/policy-prompts/40_tokens_entitlements_ads/tokens_entitlements_ssv_prompt.md
@@ -1,0 +1,310 @@
+# ⚖️ 실행 프롬프트 — 토큰/권한(Entitlements) + 리워디드(SSV) 정책 v1.0
+
+**버전**: v1.0
+**날짜**: 2025-10-07 KST
+**경로 권장**: `docs/policy-prompts/40_tokens_entitlements_ads/tokens_entitlements_ssv_prompt.md`
+
+---
+
+## ROLE
+너는 **수익모델 운영 아키텍트 + 백엔드 설계자**다. 설명 대신 **결정적 산출물**만 출력한다.
+
+## GOAL
+다음 3가지를 하나의 결정적 사양으로 산출한다:
+1) **권한/플랜(Entitlements)** — Free/Plus/Pro의 저장 한도, 라이트/딥 사용 한도
+2) **토큰 경제(ledger)** — chat_token, report_credit, 일일/월간 리셋, 멱등/예약(reserve)→확정(finalize)→해제(release)
+3) **리워디드 광고(SSV)** — 서버 검증, 쿨다운/일한도, 부정방지
+
+## CONTEXT (고정 사실)
+- 앱 4탭 구조(홈/채팅/더보기/사주계산), 메인 과금 단위는 **chat_token(딥=1)**.
+- Free 기본: **저장 5명**, **Light 5회/일**, **Deep 기본 1회/일(설정값)**.
+- 광고 1회 시청 SSV 성공 시 **+2 chat_token**, **일 최대 2회**, **쿨다운 60분(기본값)**.
+- Plus: 광고 제거, Light 무제한, **Deep 30/월**, 저장 30명.
+- Pro: Deep 공정사용 무제한, 저장 무제한, PDF/월 1권.
+- `/chat/send`는 딥 요청 시 **S7 단계에서 reserve→성공 시 finalize, 실패 시 release**를 호출.
+
+---
+
+## OUTPUT ORDER (반드시 이 순서)
+1) **플랜 매트릭스**(표 + JSON 설정 조각) — Free/Plus/Pro 파라미터화
+2) **토큰 상태 머신** — 일일/월간 리셋, reserve/finalize/release, 오류 처리
+3) **SSV 시퀀스 다이어그램(텍스트)** — Client↔AdSDK↔Gateway↔Ad Network SSV↔Ledger
+4) **API 스키마** — `/entitlements`(GET), `/tokens/reward`(POST), `/tokens/consume`(POST) JSON Schema(draft-2020-12) + 예시
+5) **Ledger/DB 스키마** — 테이블 정의(DDL 유사), 멱등키/유니크 제약
+6) **레이트리밋/쿨다운/일한도** — 공식 규칙표
+7) **부정 방지 체크리스트** — SSV 서명 검증, 디바이스/세션 제한, 중복감지
+8) **테스트 명세** — 단위/통합 케이스 목록과 기대 결과
+9) **수용 기준(AC)**
+
+---
+
+## 1) 플랜 매트릭스
+
+### 표
+| 플랜 | 저장 한도 | Light/일 | Deep/일(기본) | Deep/월(총) | 광고 보상 | PDF 포함 | 비고 |
+|---|---:|---:|---:|---:|---:|---:|---|
+| Free | 5 | 5 | 1 | 0 | +2/token · 일2회 · 60분 쿨다운 | 0 | 배너 최소, 리워디드 중심 |
+| Plus | 30 | 무제한 | 5 | 30 | 필요없음 | 0 | 광고 제거 |
+| Pro | 무제한 | 무제한 | 무제한* | 무제한* | 필요없음 | 1/월 | *공정사용 정책 |
+
+### 구성(JSON 설정 조각; 코드에서 로딩)
+```json
+{
+  "plans": {
+    "free": {
+      "storage_limit": 5,
+      "light_daily": 5,
+      "deep_daily_base": 1,
+      "deep_monthly_quota": 0,
+      "reward": {"tokens_per_ad": 2, "daily_cap": 2, "cooldown_min": 60}
+    },
+    "plus": {
+      "storage_limit": 30,
+      "light_daily": -1,
+      "deep_daily_base": 5,
+      "deep_monthly_quota": 30,
+      "reward": null
+    },
+    "pro": {
+      "storage_limit": -1,
+      "light_daily": -1,
+      "deep_daily_base": -1,
+      "deep_monthly_quota": -1,
+      "reward": null,
+      "pdf_per_month": 1,
+      "fair_use_note": "과도 사용시 제한 가능"
+    }
+  }
+}
+```
+
+---
+
+## 2) 토큰 상태 머신
+
+- **일일 리셋(00:00 로컬)**: `light_daily_left = plan.light_daily`, `deep_daily_left = plan.deep_daily_base`.
+- **월간 리셋(매월 1일 00:00)**: `deep_monthly_left = plan.deep_monthly_quota`.
+- **소비 플로우(딥 요청)**
+  1. `RESERVE`: `/tokens/consume(op=reserve, amount=1, reason="chat_deep", idempotency_key)`
+  2. LLM 처리 성공 시 `FINALIZE`: `/tokens/consume(op=finalize, idem=...)`
+  3. 실패/취소 시 `RELEASE`: `/tokens/consume(op=release, idem=...)`
+- **차감 순서**: `deep_daily_left → deep_monthly_left → chat_token(balance)` (남는 경로 없음 시 Upsell)
+- **에러 시나리오**:
+  - `reserve` 성공 후 네트워크 단절 → 동일 `idempotency_key`로 재시도 시 **멱등 성공**
+  - `finalize` 중복 호출 → **무효(no-op)**
+  - `release` 전에 `finalize` 완료 → `release`는 **무효(no-op)**
+
+---
+
+## 3) SSV 시퀀스(텍스트 다이어그램)
+
+```
+User → App(더보기/모달): "광고 보고 토큰 얻기" 선택
+App → Ad SDK: Show Rewarded
+Ad SDK → AdNet: requestAd
+AdNet → Ad SDK: adFilled
+[사용자 시청 완료]
+Ad SDK → App: client_receipt (opaque)
+App → Gateway POST /tokens/reward {network, receipt, idempotency_key}
+Gateway → AdNet SSV: verify(receipt, app_user, device, ts, signature)
+AdNet → Gateway: {status: "verified", reward_id, signature_ok}
+Gateway → Ledger: grant +2 tokens (idempotency_key unique)
+Ledger → Gateway: new_balance
+Gateway → App: {granted:2, cooldown_sec: 3600, daily_remaining:1, balance:new_balance}
+```
+
+- **실패 분기**: 서명 불일치/만료/중복 → 보상 거절(`E_SSV_INVALID`/`E_SSV_DUPLICATE`).
+
+---
+
+## 4) API 스키마 (JSON Schema, draft-2020-12)
+
+### 4.1 `GET /api/v1/entitlements` (응답)
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "type":"object",
+  "required":["plan","storage_limit","stored","light_daily_left","deep_daily_left","deep_monthly_left"],
+  "properties": {
+    "plan": {"type":"string","enum":["free","plus","pro"]},
+    "storage_limit": {"type":"integer"},
+    "stored": {"type":"integer"},
+    "light_daily_left": {"type":"integer"},
+    "deep_daily_left": {"type":"integer"},
+    "deep_monthly_left": {"type":"integer"},
+    "chat_token_balance": {"type":"integer"},
+    "pdf_credits": {"type":"integer"},
+    "reward": {
+      "type":"object",
+      "properties": {
+        "eligible": {"type":"boolean"},
+        "cooldown_sec": {"type":"integer"},
+        "daily_remaining": {"type":"integer"}
+      }
+    }
+  }
+}
+```
+
+### 4.2 `POST /api/v1/tokens/reward` (요청/응답)
+요청:
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "type":"object",
+  "required":["network","receipt","idempotency_key"],
+  "properties": {
+    "network": {"type":"string","enum":["admob","ironsource","unity","applovin"]},
+    "receipt": {"type":"string","minLength":16},
+    "idempotency_key": {"type":"string","minLength":16}
+  },
+  "additionalProperties": false
+}
+```
+응답:
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "type":"object",
+  "required":["granted","balance","cooldown_sec","daily_remaining","signatures"],
+  "properties": {
+    "granted": {"type":"integer"},
+    "balance": {"type":"integer"},
+    "cooldown_sec": {"type":"integer"},
+    "daily_remaining": {"type":"integer"},
+    "signatures": {"type":"object","properties":{"sha256":{"type":"string","pattern":"^[A-Fa-f0-9]{64}$"}}}
+  }
+}
+```
+
+### 4.3 `POST /api/v1/tokens/consume` (요청/응답)
+요청:
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "type":"object",
+  "required":["op","reason","idempotency_key"],
+  "properties": {
+    "op": {"type":"string","enum":["reserve","finalize","release"]},
+    "reason": {"type":"string","enum":["chat_deep","report_pdf"]},
+    "amount": {"type":"integer","minimum":1,"default":1},
+    "idempotency_key": {"type":"string","minLength":16}
+  },
+  "additionalProperties": false
+}
+```
+응답:
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "type":"object",
+  "required":["status","balance","deep_daily_left","deep_monthly_left"],
+  "properties": {
+    "status": {"type":"string","enum":["reserved","finalized","released","noop"]},
+    "balance": {"type":"integer"},
+    "deep_daily_left": {"type":"integer"},
+    "deep_monthly_left": {"type":"integer"},
+    "signatures": {"type":"object","properties":{"sha256":{"type":"string","pattern":"^[A-Fa-f0-9]{64}$"}}}
+  }
+}
+```
+
+---
+
+## 5) Ledger/DB 스키마 (DDL 유사)
+
+```sql
+-- 사용자 플랜/권한
+CREATE TABLE entitlements (
+  user_id TEXT PRIMARY KEY,
+  plan TEXT NOT NULL CHECK (plan IN ('free','plus','pro')),
+  storage_limit INTEGER NOT NULL,
+  light_daily_left INTEGER NOT NULL,
+  deep_daily_left INTEGER NOT NULL,
+  deep_monthly_left INTEGER NOT NULL,
+  chat_token_balance INTEGER NOT NULL DEFAULT 0,
+  pdf_credits INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMP NOT NULL
+);
+
+-- 토큰 원장
+CREATE TABLE tokens_ledger (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  type TEXT NOT NULL CHECK (type IN ('grant','reserve','finalize','release','consume_refund')),
+  amount INTEGER NOT NULL,
+  reason TEXT,
+  idempotency_key TEXT NOT NULL,
+  balance_after INTEGER NOT NULL,
+  meta JSONB,
+  created_at TIMESTAMP NOT NULL,
+  UNIQUE (user_id, idempotency_key)
+);
+
+-- 광고 보상 영수증
+CREATE TABLE ad_rewards (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  network TEXT NOT NULL,
+  receipt_hash TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending','verified','rejected','duplicate')),
+  idempotency_key TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  UNIQUE (network, receipt_hash),
+  UNIQUE (user_id, idempotency_key)
+);
+```
+
+- **원칙**: 모든 변동은 **원장 기반**(append-only). 실시간 잔액은 `balance_after`로 파생.
+- **멱등**: `(user_id, idempotency_key)` 유니크로 중복 방지.
+
+---
+
+## 6) 레이트리밋/쿨다운/일한도
+
+| 항목 | 규칙 | 기본값 |
+|---|---|---|
+| `/tokens/reward` 쿨다운 | 최근 성공 이후 X분 전엔 거절 | 60분 |
+| `/tokens/reward` 일한도 | 일 최대 N회 성공 | 2회 |
+| `/tokens/consume reserve` | 초당 요청 제한 | 10 rps/user |
+| `/entitlements` 조회 | 초당 요청 제한 | 5 rps/user |
+
+---
+
+## 7) 부정 방지 체크리스트
+1. **SSV 서명 검증**: 네트워크 공개키/시크릿으로 수검증. 시간유효성(`ts` ±300s).
+2. **영수증 중복**: `receipt_hash` 유니크.
+3. **디바이스/세션**: device_id / IP / 플랫폼 로그 병행 수집, 비정상 패턴 차단.
+4. **쿨다운/일한도**: 서버 기준으로 적용(클라이언트 표시와 독립).
+5. **리스크 플래그**: 과도 시청/짧은 체류시간/루프 의심 시 계정 제한.
+
+---
+
+## 8) 테스트 명세
+
+- **단위**
+  - `reserve→finalize` 잔액·일/월 카운터 정확 반영
+  - `reserve→release` 시 잔액 불변
+  - 멱등키 중복 호출 시 **noop**
+  - 보상 SSV 성공/실패/중복
+
+- **통합**
+  - Free 사용자가 딥 2회: 1회(기본), 1회(광고 보상) → 성공
+  - 쿨다운 위반 시 거절, 안내 값(cooldown_sec) 정확
+  - 일한도 초과 시 `E_REWARD_DAILY_CAP`
+  - 네트워크 장애 시 재시도 정책 검증
+
+---
+
+## 9) 수용 기준(AC)
+- 플랜 매트릭스와 JSON 설정 조각이 포함되어야 함
+- 상태 머신(리셋/소비)과 SSV 시퀀스가 명확해야 함
+- 3개 API의 요청/응답 **JSON Schema**와 **예시**가 포함되어야 함
+- DDL 유사 스키마와 멱등/유니크 규칙 명시
+- 레이트리밋/쿨다운/일한도 표 제시, 부정 방지 리스트 포함
+- 테스트 명세(단위/통합)가 존재
+
+---
+
+## NOW OUTPUT
+위 요구사항을 모두 충족하는 **단일 사양 문서**를 생성하라. 설명이 아닌 **스펙/표/스키마/시퀀스/테스트**만 출력한다.

--- a/docs/policy-prompts/50_cache_storage_qc/cache_storage_idempotency_prompt.md
+++ b/docs/policy-prompts/50_cache_storage_qc/cache_storage_idempotency_prompt.md
@@ -1,0 +1,321 @@
+# 🧱 실행 프롬프트 — Cache · Storage · Idempotency v1.0
+
+**ROLE**
+너는 KO-first **플랫폼 엔지니어**다. **설명 금지**, **결정적 사양만** 출력한다.
+
+**GOAL**
+사주앱의 핵심 경로에 대한 **캐시 키/TTL/무결성 서명(RFC‑8785+SHA‑256)**, **오브젝트 스토리지 레이아웃**, **멱등·락·리트라이**, **DDL/스키마**, **품질검증(QC) 체크리스트**, **테스트 명세**를 한 문서로 산출한다.
+출력물은 **표 + JSON 스키마 + DDL + 시퀀스 + 테스트**로 구성되어, 바로 코드화 가능해야 한다.
+
+**SCOPE (엔드포인트별 적용)**
+- `POST /api/v1/report/saju`  *(핵심 리포트; JSON+PDF 서명/저장)*
+- `POST /api/v1/chat/send`    *(텍스트 응답; 멱등 옵션, 캐시 가능)*
+- `POST /api/v1/luck/annual`  *(연운 캐시)*
+- `POST /api/v1/luck/monthly` *(월운 캐시; 절기 경계 주의)*
+- `POST /api/v1/tokens/reward` *(SSV; 멱등키 필수)*
+- `POST /api/v1/tokens/consume`*(reserve/finalize/release 멱등)*
+- `GET  /api/v1/entitlements`  *(짧은 TTL 캐시 가능)*
+
+---
+
+## OUTPUT ORDER (반드시 이 순서)
+1) **캐시 계층 & 키/TTL 표**(서비스별 키 규칙/TTL/무효화 트리거/스토리지 클래스)
+2) **Canonical JSON & 서명 규칙**(RFC‑8785, SHA‑256, `signatures.sha256`)
+3) **오브젝트 스토리지 레이아웃**(JSON/PDF 경로 규칙, ETag/MD5, 보관/삭제 정책)
+4) **멱등성/락/리트라이 정책**(키 스코프, 중복 처리, 분산락, 타임아웃)
+5) **스키마**: CacheEnvelope, StorageIndex, IdempotencyRecord, LockLease(JSON Schema)
+6) **DDL**(PostgreSQL/Redis 키스페이스/오브젝트 스토어 디렉토리 규칙)
+7) **시퀀스 다이어그램**(report, chat, reward, consume)
+8) **품질검증(QC) 체크리스트**(서명, evidence, policy 적용)
+9) **테스트 명세**(단위/통합/경계)
+10) **수용 기준(AC)**
+
+---
+
+## 1) 캐시 계층 & 키/TTL 표
+
+### 1.1 레벨
+- L1: 메모리(프로세스) · 초단위 TTL
+- L2: Redis(클러스터) · 분 단위 TTL
+- L3: 오브젝트 스토어(JSON 스냅샷/ PDF) · 버전/불변
+
+### 1.2 키 규칙/TTL/무효화 (표)
+| 영역 | Key 패턴 | TTL | 무효화 트리거 | 비고 |
+|---|---|---:|---|---|
+| **astro** 절기 | `astro:terms:{year}` | 365d | 데이터 리프레시 | CSV prewarm |
+| **pillars** | `pillars:{profile_id}:{inputs_hash}` | 30d | 입력 변경(시간/zi/solar) | inputs_hash=RFC‑8785 hash |
+| **analysis** | `analysis:{profile_id}:{pillars_sha}:{flags_hash}` | 30d | 정책 파일 버전 변경 | flags: climate/palace/combination |
+| **luck:years** | `luck:years:{profile_id}:{YYYY}` | 365d | 정책/절기 데이터 변경 | 캐시 히트 우선 |
+| **luck:months** | `luck:months:{profile_id}:{YYYY-MM}` | 30d | 절기 경계 월만 강제 갱신 | 입절±2일 주의 |
+| **report:saju** | `report:saju:{profile_id}:{report_sha}` | 90d | 재생성/정책 메이저업 | L3 스냅샷 핸들 |
+| **chat:send** | `chat:light:{profile_id}:{prompt_fp}` | 24h | 템플릿/가드 버전업 | Light만 기본 캐시 |
+| **entitlements** | `ent:{user_id}` | 60s | 토큰/리워드 변동 | 강한 일관성 불필요 |
+| **tokens:reward cooldown** | `reward:cooldown:{user_id}` | 60m | 성공 시 설정 | 일한도 별도키 |
+| **tokens:reward dailycap** | `reward:daycap:{user_id}:{YYYYMMDD}` | 24h | 리셋 | 누적 카운트 |
+
+---
+
+## 2) Canonical JSON & 서명 규칙
+
+- 정규화: **RFC‑8785**(키 정렬, 수치 표준화, UTF‑8, NaN 금지)
+- 서명: `sha256(canonical_json_bytes)` → hex 64자 → `signatures.sha256`에 저장
+- 서명 대상: `/report/saju` 최종 응답, `/chat/send` 최종 텍스트 래퍼, `/tokens/*` 응답
+- 검증: 게이트웨이 레벨에서 **응답 서명 검증 후** 전송
+
+**Schema: SignatureBlock**
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "type":"object",
+  "properties":{"sha256":{"type":"string","pattern":"^[A-Fa-f0-9]{64}$"}}
+}
+```
+
+---
+
+## 3) 오브젝트 스토리지 레이아웃
+
+- **버킷**: `saju-{env}-{region}`
+- **경로 규칙**:
+  - JSON 스냅샷: `snapshots/report-saju/{profile_id}/{yyyy}/{mm}/r_{timestamp}_{sha8}.json`
+  - PDF: `reports/pdf/{profile_id}/{yyyy}/{mm}/r_{timestamp}_{sha8}.pdf`
+- **메타**: `Content-Type`, `Content-MD5`(ETag), `x-signature-sha256`
+- **보관/삭제**: JSON/PDF 90일 기본, Pro 플랜은 1년
+- **접근**: 사설 버킷 + 서명 URL(15분) 발급
+
+**Schema: StorageIndex**
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "type":"object",
+  "required":["path","sha256","size","mime","created_at"],
+  "properties":{
+    "path":{"type":"string"},
+    "sha256":{"type":"string","pattern":"^[A-Fa-f0-9]{64}$"},
+    "size":{"type":"integer","minimum":0},
+    "mime":{"type":"string"},
+    "created_at":{"type":"string","format":"date-time"},
+    "etag":{"type":"string"},
+    "signed_url":{"type":"string"}
+  }
+}
+```
+
+---
+
+## 4) 멱등성/락/리트라이 정책
+
+### 4.1 멱등 키 스코프
+| 엔드포인트 | 키 필드 | 유니크 제약 | 만료 |
+|---|---|---|---|
+| `/tokens/reward` | `idempotency_key` | `(user_id, idempotency_key)` | 2d |
+| `/tokens/consume` | `idempotency_key` | `(user_id, idempotency_key)` | 2d |
+| `/report/saju` | `inputs_hash` | `(profile_id, inputs_hash)` | 30d |
+| `/chat/send` | `prompt_fp` | `(profile_id, prompt_fp, depth)` | 24h |
+
+### 4.2 분산 락(충돌 방지)
+- **키**: `lock:{scope}:{hash}` / TTL=15s / 리뉴얼 허용
+- **취득 실패 시**: 409 반환 또는 큐잉(선택)
+
+**Schema: LockLease**
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "type":"object",
+  "required":["key","owner","ttl_ms","acquired_at"],
+  "properties":{
+    "key":{"type":"string"},
+    "owner":{"type":"string"},
+    "ttl_ms":{"type":"integer","minimum":1000},
+    "acquired_at":{"type":"string","format":"date-time"}
+  }
+}
+```
+
+### 4.3 리트라이
+- 네트워크/5xx/timeout → 지수 백오프(200ms, 400ms, 800ms 최대)
+- 동일 입력 해시 30초 내 재시도 금지(쿨다운)
+
+---
+
+## 5) 스키마(JSON Schema)
+
+### CacheEnvelope
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "type":"object",
+  "required":["cache_key","created_at","ttl_sec","payload","signatures"],
+  "properties":{
+    "cache_key":{"type":"string"},
+    "created_at":{"type":"string","format":"date-time"},
+    "ttl_sec":{"type":"integer","minimum":1},
+    "payload":{"type":"object"},
+    "source":{"type":"string","enum":["L1","L2","L3","MISS"]},
+    "signatures":{"$ref":"#/defs/SignatureBlock"}
+  },
+  "defs":{
+    "SignatureBlock":{"type":"object","properties":{"sha256":{"type":"string","pattern":"^[A-Fa-f0-9]{64}$"}}}
+  }
+}
+```
+
+### IdempotencyRecord
+```json
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "type":"object",
+  "required":["key","scope","status","first_seen_at"],
+  "properties":{
+    "key":{"type":"string","minLength":16},
+    "scope":{"type":"string","enum":["reward","consume","report","chat"]},
+    "status":{"type":"string","enum":["reserved","finalized","released","replayed"]},
+    "first_seen_at":{"type":"string","format":"date-time"},
+    "last_used_at":{"type":"string","format":"date-time"},
+    "response_hash":{"type":"string","pattern":"^[A-Fa-f0-9]{64}$"}
+  }
+}
+```
+
+---
+
+## 6) DDL (PostgreSQL) & Redis 키스페이스
+
+### PostgreSQL
+```sql
+-- 캐시 인덱스(옵션: 관측 용도)
+CREATE TABLE cache_index (
+  cache_key TEXT PRIMARY KEY,
+  ttl_sec INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  hits BIGINT NOT NULL DEFAULT 0,
+  meta JSONB
+);
+
+-- 스토리지 색인
+CREATE TABLE storage_index (
+  id TEXT PRIMARY KEY,
+  path TEXT NOT NULL,
+  sha256 CHAR(64) NOT NULL,
+  size BIGINT NOT NULL,
+  mime TEXT NOT NULL,
+  etag TEXT,
+  created_at TIMESTAMP NOT NULL,
+  signed_url TEXT
+);
+
+-- 멱등
+CREATE TABLE idempotency_keys (
+  user_id TEXT NOT NULL,
+  key TEXT NOT NULL,
+  scope TEXT NOT NULL CHECK (scope IN ('reward','consume','report','chat')),
+  status TEXT NOT NULL CHECK (status IN ('reserved','finalized','released','replayed')),
+  response_hash CHAR(64),
+  first_seen_at TIMESTAMP NOT NULL,
+  last_used_at TIMESTAMP NOT NULL,
+  PRIMARY KEY (user_id, key)
+);
+```
+
+### Redis 키스페이스 예
+```
+L1:process:   (내부 메모리)
+L2:redis:
+  astro:terms:{year}
+  pillars:{profile_id}:{inputs_hash}
+  analysis:{profile_id}:{pillars_sha}:{flags_hash}
+  luck:years:{profile_id}:{YYYY}
+  luck:months:{profile_id}:{YYYY-MM}
+  report:saju:{profile_id}:{report_sha}
+  chat:light:{profile_id}:{prompt_fp}
+  reward:cooldown:{user_id}
+  reward:daycap:{user_id}:{YYYYMMDD}
+  lock:{scope}:{hash}
+```
+
+---
+
+## 7) 시퀀스 다이어그램(텍스트)
+
+### 7.1 /report/saju
+```
+Client → Gateway: POST /report/saju(body)
+Gateway → L2: GET pillars:{profile}:{inputs_hash} (MISS)
+… services 호출 체인 …
+Gateway: canonicalize → sha256 → signatures.sha256
+Gateway → L3: PUT snapshots/report-saju/… (JSON)
+Gateway → L2: SET report:saju:{profile}:{report_sha} (90d)
+Gateway → Client: 200 {signatures.sha256, storage_index}
+```
+
+### 7.2 /chat/send (light)
+```
+Client → Gateway: POST /chat/send(light)
+Gateway → L2: GET chat:light:{profile}:{prompt_fp} (HIT?) → 있으면 즉시 반환
+없으면 템플릿→LLM→Post-Guard→canonicalize→서명→L2 SET(24h)
+```
+
+### 7.3 tokens/reward
+```
+Client → Gateway: POST /tokens/reward {idempotency_key}
+Gateway → Redis: SETNX lock:reward:{hash} (15s)
+  ↳ 실패 시 409
+Gateway → idempotency_keys UPSERT (reserved)
+Gateway → AdNet SSV verify → OK
+Gateway → Ledger grant → response_hash 생성
+Gateway → idempotency_keys UPDATE (finalized)
+Gateway → Redis: DEL lock
+Gateway → Client: 200 {granted, balance, signatures.sha256}
+```
+
+### 7.4 tokens/consume (reserve→finalize→release)
+```
+reserve: UPSERT(reserved) → balance check → 200
+finalize: UPDATE(finalized) → 200
+release: UPDATE(released) → 200
+재호출: status 기준 noop/replayed
+```
+
+---
+
+## 8) 품질검증(QC) 체크리스트
+
+- ✓ canonical JSON 생성 후 동일 입력 → 동일 sha256 확인
+- ✓ `/report/saju`에 `evidence.policies_applied[]` 포함
+- ✓ 절기 경계(월운) ±2일 캐시 강제 갱신
+- ✓ `unknown_hour:true`는 `pillars.hour=null`로 캐시 키에 반영
+- ✓ `zi_hour_mode`, `use_solar_time`, `apply_combination_wuxing_change`는 `flags_hash`에 포함
+- ✓ PDF 업로드 시 `Content-MD5`/`ETag` 검증
+
+---
+
+## 9) 테스트 명세
+
+### 단위
+- canonicalize 동일 입력 해시 불변
+- CacheEnvelope 스키마 통과, TTL 만료 후 MISS
+- idempotency_keys: reserve→finalize 멱등, release noop
+
+### 통합
+- `/report/saju` 두 번 호출 → 두 번째는 L2/L3 HIT
+- `/luck/monthly` 절기 경계 월에서 캐시 새로고침
+- `tokens/reward` 동일 idempotency_key 두 번 → 두 번째는 DUPLICATE
+- `/chat/send(light)` 동일 prompt_fp → 캐시 HIT
+
+### 경계
+- 락 만료 전 재취득 실패(409)
+- 장문 컨텍스트(>32k) 경로에서 캐시/스토리지 정상화
+
+---
+
+## 10) 수용 기준(AC)
+- 키/TTL 표와 무효화 규칙이 완전하며, `flags_hash`/`inputs_hash` 정의가 포함될 것
+- RFC‑8785 기반 서명 규칙과 SignatureBlock 스키마 포함
+- 오브젝트 스토리지 경로/보관/서명 URL 정책 명시
+- 멱등/락/리트라이 정책과 IdempotencyRecord/LockLease 스키마 포함
+- DDL/Redis 키스페이스/시퀀스/QA·테스트 명세 완비
+
+---
+
+## NOW OUTPUT
+위 형식을 그대로 따라 Cache·Storage·Idempotency 사양 문서를 생성하라. 불필요한 설명·주석 없이 표/JSON/DDL/시퀀스/테스트만 출력.

--- a/docs/policy-prompts/50_cache_storage_qc/qa_perf_release_plan_prompt.md
+++ b/docs/policy-prompts/50_cache_storage_qc/qa_perf_release_plan_prompt.md
@@ -1,0 +1,198 @@
+# ✅ 실행 프롬프트 — QA · 성능 · 릴리즈 플랜 v1.0
+
+**ROLE**
+너는 KO-first **QA 리드 & 릴리즈 매니저**다. **설명 금지**, **결정적 사양만** 출력한다.
+
+**GOAL**
+사주앱의 **품질 보증(QA)·성능·릴리즈 플랜**을 하나의 문서로 산출한다.
+산출물은 즉시 실행 가능한 **테이블/체크리스트/목표치/시나리오/테스트 명세**로 구성된다.
+
+**CONTEXT (고정)**
+- 엔드포인트: `/api/v1/report/saju`, `/api/v1/chat/send`, `/api/v1/luck/annual`, `/api/v1/luck/monthly`, `/api/v1/tokens/{reward,consume}`, `/api/v1/entitlements`, `/api/v1/report/pdf`
+- 엔진/정책: Pillars/Astro/TZ-Time/Analysis(십성·관계·강약·격국·신살·조후·용신) + (신규) 12운성/공망/원진/합화오행, 연·월운
+- LLM: 템플릿→LLM-polish, Guard v1(Pre/Post), 모델 라우팅 정책(Light/Deep)
+- 캐시/서명: RFC‑8785 canonical + `signatures.sha256`, L1/L2/L3 캐시, 멱등·락 정책
+
+---
+
+## OUTPUT ORDER (반드시 이 순서)
+1) **품질 목표(SLO/SLI)**
+2) **테스트 매트릭스(단위/컴포넌트/계약/통합/E2E)**
+3) **테스트 데이터셋(10 프로필 · 경계값 포함)**
+4) **성능/부하 계획(k6/JMeter 수준의 시나리오 & 목표)**
+5) **비용·COGS 관측 & 목표**
+6) **보안·프라이버시·부정방지(SSV/멱등/서명)**
+7) **모니터링/알림 대시보드 설계**
+8) **릴리즈 플랜(스테이징→카나리→점진 확대) & 롤백 전략**
+9) **런북(사고 대응 절차)**
+10) **테스트 명세(케이스·수용 기준)**
+11) **최종 Go/No-Go 체크리스트**
+12) **Now Output 지시**
+
+---
+
+## 1) 품질 목표(SLO/SLI)
+
+| 항목 | 목표 | 측정 방식 |
+|---|---|---|
+| 가용성 | ≥ 99.5% 월간 | 5xx/타임아웃 비율 |
+| `/chat/send` 지연 | **Light** p50 ≤ 1.5s / p95 ≤ 3.5s / p99 ≤ 6s<br>**Deep** p50 ≤ 3.5s / p95 ≤ 8s / p99 ≤ 12s | 게이트웨이 타이머 |
+| `/report/saju` 지연 | p50 ≤ 2.5s / p95 ≤ 6s | 체인 합산 |
+| Guard 정합성 | Post-Guard **block ≤ 2%**, **patch ≤ 25%(Light), ≤ 15%(Deep)** | Guard 결과 이벤트 |
+| 캐시 적중 | `/chat/send(light)` L2 히트율 ≥ 60% | Redis 히트율 |
+| 스키마 준수 | JSON Schema 유효성 100% | ajv/jsonschema |
+| SSV 정확성 | 중복 보상 0, 서명 검증 100% | 원장/SSV 로그 |
+| 오류 예산 | 월간 실패 ≤ 0.5% | 오류율 집계 |
+| 데이터 무결성 | 서명 검증 성공 100% | sha256 검증 |
+
+---
+
+## 2) 테스트 매트릭스
+
+### 2.1 레이어별
+- **Unit**: life_stage/void/yuanjin/combination, luck_annual/monthly, tokens ledger
+- **Component**: tz-time/astro/pillars/analysis/luck/llm-polish/guard
+- **Contract**: `/report/saju`, `/chat/send`, `/luck/*`, `/tokens/*` JSON Schema
+- **Integration**: 서비스 체인(UTC↔LMT/절기/월주 경계/합화 가중)
+- **E2E**: 프로필 저장→리포트→채팅(라이트/딥)→업셀→광고 보상→딥 재시도
+
+### 2.2 파라미터 조합(샘플)
+| 축 | 값 |
+|---|---|
+| calendar_type | solar / lunar |
+| unknown_hour | true / false |
+| zi_hour_mode | default / split_23 |
+| timezone | UTC±, DST 경계(예: America/Los_Angeles) |
+| solar_time | on/off |
+| relation flags | combination_wuxing on/off |
+| month boundary | 입절 직전/직후(±1분) |
+| d/un | forward / reverse |
+| load | 동시성 1/10/50(라이트), 1/5/20(딥) |
+
+---
+
+## 3) 테스트 데이터셋(10 프로필)
+
+- **P1**: 서울 1999‑02‑05 23:30 split_23, DST X
+- **P2**: 뉴욕 1988‑06‑05 01:05 DST on 경계
+- **P3**: 도쿄 2001‑11‑07 12:00 solar_time on
+- **P4**: 파리 1975‑04‑05 00:10 입절 직후
+- **P5**: 시드니 1990‑12‑22 22:50 역행 대운
+- **P6**: 서울 2000‑09‑14 10:00 합화 on
+- **P7**: 베를린 1964‑02‑29 08:00 윤년
+- **P8**: 상파울루 1993‑10‑17 23:55 unknown_hour
+- **P9**: 타이베이 1986‑08‑08 14:20
+- **P10**: 런던 2003‑03‑01 05:45 (DST 전)
+
+각 프로필에 `/report/saju`, `/chat/send(light/deep)`, `/luck/*` 수행.
+
+---
+
+## 4) 성능/부하 계획
+
+### 4.1 시나리오(k6 의사코드)
+- **S1 Light Cached**: 60% 캐시 히트 가정, RPS 30, 15분
+- **S2 Light Cold**: 캐시 미스, RPS 10, 10분
+- **S3 Deep Mixed**: RPS 3, 동시성 15, 20분 (fallback 10% 유도)
+- **S4 Report Batch**: 동시 5, 200건
+- **S5 Tokens Flow**: reward→consume 예약/확정/해제 50 tpm
+
+### 4.2 목표
+- **S1**: p95 ≤ 3.0s / 오류율 ≤ 1%
+- **S2**: p95 ≤ 4.0s
+- **S3**: p95 ≤ 8.0s / 백스톱 비율 ≤ 5%
+- **S4**: 평균 ≤ 6.0s, 실패 0
+- **CPU/메모리**: 게이트웨이 p95 CPU ≤ 70%, RSS ≤ 600MB/인스턴스
+
+### 4.3 결과 산출물
+- 부하 리포트(JSON/HTML), 타임시리즈 그래프, 병목 분석(Top N)
+
+---
+
+## 5) 비용·COGS 관측 & 목표
+
+| 항목 | 목표치 |
+|---|---|
+| Light 1회 추정비용 | 기준값 ≤ 1.0 단위(상대) |
+| Deep 1회 추정비용 | 기준값 ≤ 5.0 단위(상대) |
+| ARPMAU | ≥ 기준치 |
+| 광고→딥 전환율 | ≥ 15% |
+| 캐시로 절감된 LLM 호출 | ≥ 40% |
+
+**방법**: `billing.sample` 이벤트로 모델별 추정치 수집, 월간 대시보드 집계.
+
+---
+
+## 6) 보안·프라이버시·부정방지
+
+- **PII/프라이버시**: 이름/성별/생년 외 노출 차단 테스트(이메일/전화/주소 마스킹)
+- **SSV**: 서명 검증/만료/중복/리플레이 방지, 일한도·쿨다운 준수
+- **멱등**: `/tokens/*` reserve/finalize/release, 동일 키 재호출 noop
+- **서명**: `/report/saju`·`/chat/send` 응답 `signatures.sha256` 검증
+- **권한/요율**: Free/Plus/Pro 플로우 차단/업셀 동작
+
+---
+
+## 7) 모니터링/알림
+
+### 이벤트
+`route.decide`, `route.fallback`, `llm.request/response`, `guard.post.result`,
+`tokens.reserve/finalize/release`, `reward.success/fail`, `cache.hit/miss`.
+
+### 알림 규칙(예)
+- p95 지연 임계 초과 10분 지속 → 경고
+- Guard block > 3% (5분 이동평균) → 경고
+- SSV 실패율 > 2% (10분) → 경고
+- 5xx > 1% (5분) → 치명
+
+### 대시보드
+- 성능(지연/성공률), 비용, Guard 패치율, 캐시 히트율, 토큰 흐름
+
+---
+
+## 8) 릴리즈 플랜 & 롤백
+
+| 단계 | 대상 | 비율 | 기간 | 게이트(통과 조건) |
+|---|---|---:|---|---|
+| **Staging** | 내부 QA | 100% | 1일 | 모든 테스트 녹색, p95 OK |
+| **Canary** | 실사용자 | 5% → 25% | 1~2일 | 오류율/지연/Guard OK |
+| **GA** | 전체 | 100% | — | KPI 안정 |
+
+**롤백**: 카나리 중 임계 초과 시 **즉시 이전 버전 복구**, 피처플래그로 Guard/라우팅/SSV 개별 비활성화.
+
+---
+
+## 9) 런북(사고 대응)
+
+- **LLM 지연 급증**: Light 라우팅 qwen→deepseek 스위치, 템플릿 축약, 타임아웃 하향
+- **Guard block 급증**: 템플릿 팩 롤백, 모델 온도 하향, 동일 모델 재시도 경로 확인
+- **SSV 장애**: 보상 중단 안내, 영수증 큐잉, 복구 후 배치 처리
+- **멱등 충돌**: 키 스코프 확인, 중복 처리 NOOP 보장
+- **캐시 적중 급락**: 키 해시 구성 변경 감시, 플래그/버전 영향 점검
+
+---
+
+## 10) 테스트 명세(케이스·수용 기준)
+
+- **계약**: 모든 응답 JSON Schema 통과(9 엔드포인트)
+- **경계**: 입절 ±1분, unknown_hour, zi_hour_mode split_23
+- **성능**: S1~S5 목표 달성, 보고서 제출
+- **보안**: PII 차단·서명 검증·SSV 성공/중복/만료
+- **비용**: 모델별 비용 샘플 1,000건 수집, 목표치 이내
+
+---
+
+## 11) Go/No-Go 체크리스트
+
+- [ ] 모든 테스트 녹색 / 리그레션 0
+- [ ] p95/오류율 목표 충족
+- [ ] Guard block/patch 비율 목표 충족
+- [ ] 비용 지표 정상 / 캐시 히트율 확보
+- [ ] 모니터링·알림·런북 준비
+- [ ] 롤백 경로 검증 완료
+
+---
+
+## 12) NOW OUTPUT
+위 형식을 **그대로** 따라 **QA · 성능 · 릴리즈 플랜 v1.0 문서**를 출력하라.
+불필요한 설명 없이 **표/체크리스트/목표/시나리오/테스트/게이트**만 제공.

--- a/docs/policy-prompts/README.md
+++ b/docs/policy-prompts/README.md
@@ -1,0 +1,255 @@
+# 📚 사주 프로젝트 — Policy Prompts Hub (README)
+
+**Version:** v1.0
+**Date:** 2025-10-07 KST
+**Path:** `docs/policy-prompts/README.md`
+
+---
+
+## 목적
+
+정책/프롬프트/스키마/플로우를 한 곳에서 관리해, **Claude(코딩)**, **GPT-5 Pro(정책/스키마)**, 기타 모델들이 일관된 산출물을 내도록 하는 **중앙 허브**.
+
+**문서 톤:** KO-first / 결정적(Deterministic) / Schema-first
+**배치 위치:** 개발 리포지토리 최상단 `docs/policy-prompts/`
+
+**핵심 원칙:**
+- 모든 산출물은 **RFC-8785 canonical JSON + SHA-256 서명** 예시 포함
+- **정책 결정**은 엔진/정책 파일이 단독 수행 → LLM은 수정 금지
+- **LLM 역할**은 설명/코칭/요약/문장 다듬기만 (템플릿 우선 → LLM 보강)
+
+---
+
+## 0) 빠른 사용법 (Claude Runbook)
+
+1. **항상 이 README를 먼저 읽고**, 각 섹션의 마스터 프롬프트를 열어 그대로 실행.
+2. 산출물은 `specs/` 또는 해당 서비스 폴더 하위에 커밋.
+3. **PR 제목 규칙:** `spec: <모듈명> vX.Y` (예: `spec: /chat/send spec v1.0`)
+4. **테스트/샘플 포함 여부** 체크리스트 통과 후 머지.
+
+---
+
+## 1) 전체 흐름도 (엔진·서비스·LLM)
+
+```
+Client (앱 4탭: 홈/채팅/더보기/사주계산)
+  ↓
+API Gateway
+  ↓
+  ├─→ tz-time-service → astro-service → pillars-service
+  │     ↓
+  ├─→ analysis-service (십성/관계/강약/격국/신살/조후/용신)
+  │     + (신규) TwelveStage / Void / Yuanjin / CombinationElement
+  │     ↓
+  ├─→ luck-service (Annual/Monthly)
+  │     ↓
+  ├─→ llm-polish (템플릿→문장화)
+  │     ↓
+  ├─→ LLMGuard (Pre/Post)
+  │     ↓
+  ├─→ billing/entitlement/tokens (권한·토큰·리워디드)
+  │     ↓
+  └─→ report-service (PDF)
+```
+
+**정책 결정(룰/수치/관계/버킷):** 엔진/정책이 단독 결정 → LLM은 수정 금지
+**LLM 역할:** 설명/코칭/요약/문장 다듬기만 수행 (템플릿 우선 → LLM 보강)
+
+---
+
+## 2) 폴더 구조 권장안
+
+```
+/docs/policy-prompts/
+  README.md                         # (현재 문서)
+  00_master/                        # 통합 마스터 프롬프트
+    Saju_Chat_Report_Integrated_Master_Prompt_v1.md
+  10_api-specs/                     # API 사양 프롬프트
+    01_openapi_lite_prompt.md       # 9개 엔드포인트 OpenAPI-lite
+    02_report_schema_prompt.md      # /report/saju JSON Schema + 샘플
+    03_chat_send_spec_prompt.md     # /chat/send 스펙(상태머신·라우팅·스키마)
+  20_policy-engines/                # 정책/엔진 프롬프트
+    relation_policy_extension_prompt.md
+    twelve_stage_void_yuanjin_combo_prompt.md
+    annual_monthly_luck_prompt.md
+  30_llm/                           # LLM 템플릿·가드·라우팅
+    llm_templates_5pack_prompt.md   # 오행/용신/강약/대운/연·월운
+    llm_guard_v1_prompt.md
+    model_routing_policy_prompt.md
+  40_tokens_entitlements_ads/       # 토큰·권한·리워디드
+    tokens_entitlements_ssv_prompt.md
+  50_cache_storage_qc/              # 캐시/스토리지/QA
+    cache_storage_idempotency_prompt.md
+    qa_perf_release_plan_prompt.md
+```
+
+각 프롬프트는 **결정적 산출물만 출력**하도록 구성 (설명문 X, 스키마/표/코드/정책만).
+
+---
+
+## 3) 현재 준비된 프롬프트 링크
+
+### 통합 마스터
+- `00_master/Saju_Chat_Report_Integrated_Master_Prompt_v1.md` (⏳ 대기)
+
+### API
+- ✅ `10_api-specs/01_openapi_lite_prompt.md` (완료 → API_SPECIFICATION_v1.0.md)
+- ✅ `10_api-specs/02_report_schema_prompt.md` (완료 → SAJU_REPORT_SCHEMA_v1.0.md)
+- ✅ `10_api-specs/03_chat_send_spec_prompt.md` (완료 → CHAT_SEND_SPEC_v1.0.md)
+
+### 정책/엔진
+- ⏳ `20_policy-engines/relation_policy_extension_prompt.md`
+- ⏳ `20_policy-engines/twelve_stage_void_yuanjin_combo_prompt.md`
+- ⏳ `20_policy-engines/annual_monthly_luck_prompt.md`
+
+### LLM
+- ⏳ `30_llm/llm_templates_5pack_prompt.md`
+- 🟡 `30_llm/llm_guard_v1_prompt.md` (계획만: LLM_GUARD_V1_ANALYSIS_AND_PLAN.md)
+- ⏳ `30_llm/model_routing_policy_prompt.md`
+
+### 토큰/광고/권한
+- ⏳ `40_tokens_entitlements_ads/tokens_entitlements_ssv_prompt.md`
+
+### 캐시/스토리지/QA
+- ⏳ `50_cache_storage_qc/cache_storage_idempotency_prompt.md`
+- ⏳ `50_cache_storage_qc/qa_perf_release_plan_prompt.md`
+
+실제 파일은 이 README 생성 이후 차례로 추가.
+
+---
+
+## 4) 공통 규약 (필수)
+
+### 파일 머리말
+
+모든 프롬프트는 다음 형식:
+
+```markdown
+# <제목>
+
+**버전**: vMAJOR.MINOR
+**날짜**: YYYY-MM-DD KST
+**경로 권장**: docs/policy-prompts/<섹션>/<파일명>
+
+## ROLE
+<역할 정의>
+
+## GOAL
+<목표 정의>
+
+## OUTPUT ORDER
+<산출물 순서>
+```
+
+### 스키마
+
+- **$schema**: `https://json-schema.org/draft/2020-12/schema`
+- **$defs** 적극 사용
+- **description** 필수
+
+### 서명
+
+샘플 JSON에는 `signatures.sha256` 포함:
+
+```json
+{
+  "meta": {
+    "signatures": {
+      "sha256": "3a7bd3e2360a3d29eea436fcfb7e44c728d239f9f78caf42aac6a1c0bd4e2e9a"
+    }
+  }
+}
+```
+
+### 한자/KO 라벨
+
+`*_ko` 병행:
+
+```json
+{
+  "strength": {
+    "bucket": "신약",
+    "bucket_ko": "신약"
+  }
+}
+```
+
+### 금지사항
+
+- LLM이 정책 수치를 임의변경
+- 의료/법률/투자 구체행위 조언
+
+---
+
+## 5) 체크리스트 (PR 머지 전)
+
+### 문서
+
+- [ ] 제목/버전/날짜(KST) 포함
+- [ ] ROLE/GOAL/OUTPUT ORDER 정의
+- [ ] JSON Schema draft-2020-12 선언
+- [ ] $defs 재사용 컴포넌트 분리
+- [ ] description 필드 모든 속성에 포함
+- [ ] 샘플 JSON 2건 이상 (정상 + 엣지)
+- [ ] signatures.sha256 포함
+- [ ] *_ko 라벨 병행 (KO-first)
+- [ ] enum/pattern 완전성 검증
+- [ ] 검증 힌트 섹션 포함
+
+### 코드
+
+- [ ] Pydantic 모델 정의
+- [ ] 정책 파일 로딩 구현
+- [ ] RFC-8785 서명 검증
+- [ ] 단위 테스트 작성 (coverage ≥80%)
+- [ ] 통합 테스트 작성
+- [ ] Type hints 완전성
+- [ ] Docstring 포함
+- [ ] 에러 핸들링
+- [ ] 로깅 추가
+- [ ] Pre-commit hooks 통과
+
+### 정책
+
+- [ ] version 필드 포함
+- [ ] signature.sha256 포함
+- [ ] JSON Schema 스키마 파일 존재
+- [ ] 스키마 검증 통과
+- [ ] 샘플 데이터 3건 이상
+- [ ] 엔진 통합 완료
+- [ ] 테스트 케이스 작성
+- [ ] 문서화 (README/claude.md)
+
+---
+
+## 6) 버전·호환성 정책
+
+- **버전 표기:** `vMAJOR.MINOR` (예: v1.0). 브레이킹 변경 시 MAJOR 증가
+- **폴더 이름·파일명에 버전 포함** 권장 (예: `*_prompt_v1.md`)
+- **스키마는 $id로 버전 URI 명시** (예: `/schemas/report_saju_v1.schema.json`)
+
+---
+
+## 7) 참고: 모델 라우팅(요지)
+
+| Depth        | 1차                     | 2차(Fallback)      | 3차(Backstop) | 용도              |
+|--------------|-------------------------|--------------------|---------------|-------------------|
+| Light        | Qwen Flash / DeepSeek   | Gemini 2.5 Pro     | GPT-5         | 짧은 코칭 (≤300t) |
+| Deep         | Gemini 2.5 Pro          | GPT-5              | —             | 상세 코칭 (≤900t) |
+| Report-style | Gemini 2.5 Pro          | GPT-5              | —             | 리포트 자동 생성  |
+
+---
+
+## 8) 다음 액션
+
+1. ✅ `10_api-specs/02_report_schema_prompt.md` 실행 → 스키마 커밋
+2. ✅ `10_api-specs/03_chat_send_spec_prompt.md` 실행 → 채팅 사양 커밋
+3. ⏳ `40_tokens_entitlements_ads/tokens_entitlements_ssv_prompt.md` 실행 → 권한/토큰/광고 정책 커밋
+
+---
+
+## 문의/유지보수
+
+**Core Architects** (백엔드/정책/데이터) — PR 리뷰 필수
+
+**Version:** v1.0 (2025-10-07 KST)


### PR DESCRIPTION
- Add llm_templates_5pack_prompt.md (5 templates: wuxing/yongshin/strength/decades/annual_monthly)
- Add llm_guard_v1_prompt.md (Pre-Gen/Post-Gen guard rules + patch language)
- Add model_routing_policy_prompt.md (model catalog + routing matrix + fallback)
- Add cache_storage_idempotency_prompt.md (L1/L2/L3 cache + RFC-8785 signatures + idempotency)
- Add qa_perf_release_plan_prompt.md (SLO/SLI + test matrix + release plan)

All prompts follow KO-first approach with deterministic output format (tables/JSON/schemas/tests). Ready for review by BE + Prompt leads.